### PR TITLE
fix: Add Windows compatibility by replacing renameio with natefinch/atomic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require github.com/google/renameio v1.0.1
 
 require (
 	github.com/chewxy/math32 v1.10.1 // indirect
+	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/viterin/partial v1.1.0 // indirect
 	github.com/viterin/vek v0.4.2 // indirect
 	golang.org/x/sys v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
 github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
+github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
+github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=


### PR DESCRIPTION
This PR fixes the Windows compatibility issue originally reported in #9.

The root cause is that the upstream dependency `github.com/google/renameio` does not support Windows, as it includes a `// +build !windows` build tag. This results in an `undefined: renameio.TempFile` error when building for Windows.

This patch replaces the usage of `renameio` with `github.com/natefinch/atomic`, a popular and well-tested library that provides cross-platform atomic file writing capabilities.

## Changes
- Replaced `renameio.TempFile` with buffer-based approach using `atomic.WriteFile`
- Updated dependencies in `go.mod`
- Maintained atomic write guarantees

## Testing
- ✅ All existing tests pass
- ✅ Successfully cross-compiled to Windows (`GOOS=windows GOARCH=amd64`)
- ✅ Tested in production project (PCAS) that depends on hnsw
- ✅ Verified atomic file operations work correctly on both platforms

This change is minimal, only affecting `encode.go`, and allows the library to be seamlessly compiled and used on Windows platforms without any workarounds.

Closes #9