### PR TITLE
Fix search result set bounded by k instead of efSearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 __debug_bin**
+/CLAUDE.md
+/commit.msg
+.claude/
+.vibe-vault.toml
+example/constitution-search/constitution-search

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.DEFAULT_GOAL := help
+
+PREFIX ?= $(HOME)/.local
+
+##@ General
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "Quick start:  make build && make test"
+
+##@ Build
+.PHONY: build
+build: ## Build all packages
+	go build ./...
+
+##@ Test
+.PHONY: test
+test: ## Run unit tests (skip integration)
+	go test -short -cover ./...
+
+.PHONY: integration
+integration: ## Run all tests including integration
+	go test -cover -count=1 ./...
+
+.PHONY: bench
+bench: ## Run benchmarks
+	go test -bench=. -benchmem -run='^$$' ./...
+
+##@ Quality
+.PHONY: vet
+vet: ## Run go vet
+	go vet ./...
+
+.PHONY: check
+check: vet test ## Run vet + unit tests
+
+##@ Install
+.PHONY: install
+install: build ## Build and install to PREFIX
+	go install ./...
+
+##@ Clean
+.PHONY: clean
+clean: ## Remove build artifacts
+	go clean ./...

--- a/distance_test.go
+++ b/distance_test.go
@@ -30,6 +30,34 @@ func TestCosineSimilarity(t *testing.T) {
 	require.InDelta(t, 0, CosineDistance(a, b), 0.000001)
 }
 
+func TestRegisterDistanceFunc(t *testing.T) {
+	custom := func(a, b []float32) float32 { return 42 }
+	RegisterDistanceFunc("custom_test", custom)
+
+	name, ok := distanceFuncToName(custom)
+	require.True(t, ok)
+	require.Equal(t, "custom_test", name)
+
+	// Clean up
+	delete(distanceFuncs, "custom_test")
+}
+
+func TestDistanceFuncToName(t *testing.T) {
+	name, ok := distanceFuncToName(CosineDistance)
+	require.True(t, ok)
+	require.Equal(t, "cosine", name)
+
+	name, ok = distanceFuncToName(EuclideanDistance)
+	require.True(t, ok)
+	require.Equal(t, "euclidean", name)
+}
+
+func TestDistanceFuncToName_Unknown(t *testing.T) {
+	unknown := func(a, b []float32) float32 { return 0 }
+	_, ok := distanceFuncToName(unknown)
+	require.False(t, ok)
+}
+
 func BenchmarkEuclideanDistance(b *testing.B) {
 	v1 := randFloats(1536)
 	v2 := randFloats(1536)

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,6 +3,7 @@ package hnsw
 import (
 	"bytes"
 	"cmp"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -176,6 +177,88 @@ func TestSavedGraph(t *testing.T) {
 	require.NoError(t, err)
 
 	requireGraphApproxEquals(t, g1.Graph, g2.Graph)
+}
+
+func TestGraph_ExportUnregisteredDistance(t *testing.T) {
+	g := newTestGraph[int]()
+	g.Distance = func(a, b []float32) float32 { return 0 }
+	g.Add(Node[int]{Key: 1, Value: Vector{1.0}})
+
+	buf := &bytes.Buffer{}
+	err := g.Export(buf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be registered")
+}
+
+func TestGraph_ImportUnknownDistance(t *testing.T) {
+	// Build a valid export first, then tamper with the distance name
+	g := newTestGraph[int]()
+	g.Add(Node[int]{Key: 1, Value: Vector{1.0}})
+
+	buf := &bytes.Buffer{}
+	err := g.Export(buf)
+	require.NoError(t, err)
+
+	// Replace "euclidean" with "bogus_fn\x00\x00" in the binary
+	data := buf.Bytes()
+	dataStr := string(data)
+	// Just import from a fresh buffer with bad distance
+	badBuf := &bytes.Buffer{}
+	// Write version, M, Ml, EfSearch, then a bad distance name
+	_, err = multiBinaryWrite(badBuf, encodingVersion, 6, 0.5, 20, "nonexistent")
+	require.NoError(t, err)
+	_ = dataStr // suppress unused
+
+	g2 := &Graph[int]{}
+	err = g2.Import(badBuf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown distance function")
+}
+
+func TestGraph_ImportBadVersion(t *testing.T) {
+	buf := &bytes.Buffer{}
+	_, err := multiBinaryWrite(buf, 999, 6, 0.5, 20, "euclidean")
+	require.NoError(t, err)
+
+	g := &Graph[int]{}
+	err = g.Import(buf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "incompatible encoding version")
+}
+
+func TestGraph_ImportTruncated(t *testing.T) {
+	g := &Graph[int]{}
+	buf := &bytes.Buffer{}
+	err := g.Import(buf)
+	require.Error(t, err)
+}
+
+func TestGraph_ExportImportStringKeys(t *testing.T) {
+	g1 := &Graph[string]{
+		M:        6,
+		Distance: CosineDistance,
+		Ml:       0.5,
+		EfSearch: 20,
+		Rng:      rand.New(rand.NewSource(0)),
+	}
+	g1.Add(
+		Node[string]{Key: "hello", Value: Vector{1, 0}},
+		Node[string]{Key: "world", Value: Vector{0, 1}},
+	)
+
+	buf := &bytes.Buffer{}
+	err := g1.Export(buf)
+	require.NoError(t, err)
+
+	g2 := &Graph[string]{}
+	err = g2.Import(buf)
+	require.NoError(t, err)
+
+	requireGraphApproxEquals(t, g1, g2)
+
+	vec, ok := g2.Lookup("hello")
+	require.True(t, ok)
+	require.Equal(t, Vector{1, 0}, vec)
 }
 
 const benchGraphSize = 100

--- a/example/constitution-search/main.go
+++ b/example/constitution-search/main.go
@@ -1,0 +1,302 @@
+// constitution-search demonstrates HNSW approximate nearest neighbor search
+// using the full text of three national constitutions (US, Canada, Mexico).
+//
+// Usage:
+//
+//	go run ./example/constitution-search "right to bear arms"
+//	go run ./example/constitution-search -k 5 "freedom of speech"
+//	go run ./example/constitution-search -save index.bin "judicial power"
+//	go run ./example/constitution-search -load index.bin "due process"
+package main
+
+import (
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/coder/hnsw"
+)
+
+const (
+	embeddingDim  = 2048
+	chunkMaxChars = 600
+)
+
+func main() {
+	k := flag.Int("k", 3, "number of results to return")
+	savePath := flag.String("save", "", "save index to file after building")
+	loadPath := flag.String("load", "", "load index from file instead of building")
+	dataDir := flag.String("data", "test-data", "directory containing .md constitution files")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: constitution-search [flags] <query>\n")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+	query := strings.Join(flag.Args(), " ")
+
+	var g *hnsw.Graph[string]
+	var chunks map[string]string // key -> original text
+	var idf *idfTable
+
+	if *loadPath != "" {
+		fmt.Printf("Loading index from %s...\n", *loadPath)
+		sg, err := hnsw.LoadSavedGraph[string](*loadPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading index: %v\n", err)
+			os.Exit(1)
+		}
+		g = sg.Graph
+		chunks = make(map[string]string)
+		// Build IDF from data dir even when loading index (needed for query embedding)
+		idf, _ = buildIDF(*dataDir)
+		fmt.Printf("Loaded %d vectors\n", g.Len())
+	} else {
+		var err error
+		g, chunks, idf, err = buildIndex(*dataDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error building index: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if *savePath != "" {
+		fmt.Printf("Saving index to %s...\n", *savePath)
+		sg := &hnsw.SavedGraph[string]{Graph: g, Path: *savePath}
+		if err := sg.Save(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving index: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Saved.")
+	}
+
+	// Search
+	queryVec := tfidfEmbedding(query, embeddingDim, idf)
+	start := time.Now()
+	results := g.SearchWithDistance(queryVec, *k)
+	elapsed := time.Since(start)
+
+	fmt.Printf("\nQuery: %q\n", query)
+	fmt.Printf("Found %d results in %v\n\n", len(results), elapsed)
+
+	for i, r := range results {
+		fmt.Printf("--- Result %d (distance: %.4f) ---\n", i+1, r.Distance)
+		fmt.Printf("Key: %s\n", r.Key)
+		if text, ok := chunks[r.Key]; ok {
+			// Show first 200 chars of the chunk
+			preview := text
+			if len(preview) > 200 {
+				preview = preview[:200] + "..."
+			}
+			fmt.Printf("Text: %s\n", preview)
+		}
+		fmt.Println()
+	}
+}
+
+// buildIDF reads all .md files in dataDir, chunks them, and returns an IDF table.
+func buildIDF(dataDir string) (*idfTable, error) {
+	files, err := filepath.Glob(filepath.Join(dataDir, "*.md"))
+	if err != nil {
+		return nil, err
+	}
+	var allTexts []string
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return nil, err
+		}
+		allTexts = append(allTexts, chunkText(string(data), chunkMaxChars)...)
+	}
+	return computeIDF(allTexts), nil
+}
+
+func buildIndex(dataDir string) (*hnsw.Graph[string], map[string]string, *idfTable, error) {
+	files, err := filepath.Glob(filepath.Join(dataDir, "*.md"))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(files) == 0 {
+		return nil, nil, nil, fmt.Errorf("no .md files found in %s", dataDir)
+	}
+
+	// First pass: collect all chunks to build IDF table
+	type docChunk struct {
+		docName string
+		index   int
+		text    string
+	}
+	var allChunks []docChunk
+	var allTexts []string
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		docName := strings.TrimSuffix(filepath.Base(f), ".md")
+		chunks := chunkText(string(data), chunkMaxChars)
+		fmt.Printf("Chunking %s (%d chunks)...\n", docName, len(chunks))
+		for i, chunk := range chunks {
+			allChunks = append(allChunks, docChunk{docName, i, chunk})
+			allTexts = append(allTexts, chunk)
+		}
+	}
+
+	idf := computeIDF(allTexts)
+	fmt.Printf("Built IDF table: %d terms from %d chunks\n", len(idf.idf), idf.numDocs)
+
+	// Second pass: embed with TF-IDF weights and index
+	g := &hnsw.Graph[string]{
+		M:        16,
+		Ml:       0.25,
+		Distance: hnsw.CosineDistance,
+		EfSearch:  100,
+		Rng:      rand.New(rand.NewSource(42)),
+	}
+
+	chunks := make(map[string]string)
+	for _, dc := range allChunks {
+		key := fmt.Sprintf("%s:%d", dc.docName, dc.index)
+		vec := tfidfEmbedding(dc.text, embeddingDim, idf)
+		g.Add(hnsw.Node[string]{Key: key, Value: vec})
+		chunks[key] = dc.text
+	}
+
+	al := hnsw.Analyzer[string]{Graph: g}
+	fmt.Printf("Index built: %d chunks, %d layers, topography: %v\n",
+		len(allChunks), al.Height(), al.Topography())
+
+	return g, chunks, idf, nil
+}
+
+func chunkText(text string, maxChars int) []string {
+	paragraphs := strings.Split(text, "\n\n")
+	var chunks []string
+	var current strings.Builder
+
+	for _, p := range paragraphs {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if current.Len() > 0 && current.Len()+len(p)+2 > maxChars {
+			chunks = append(chunks, current.String())
+			current.Reset()
+		}
+		if current.Len() > 0 {
+			current.WriteString("\n\n")
+		}
+		current.WriteString(p)
+	}
+	if current.Len() > 0 {
+		chunks = append(chunks, current.String())
+	}
+	return chunks
+}
+
+var stopWords = map[string]bool{
+	"a": true, "an": true, "and": true, "are": true, "as": true, "at": true,
+	"be": true, "by": true, "for": true, "from": true, "has": true, "he": true,
+	"in": true, "is": true, "it": true, "its": true, "of": true, "on": true,
+	"or": true, "that": true, "the": true, "to": true, "was": true, "were": true,
+	"will": true, "with": true, "this": true, "but": true, "they": true,
+	"have": true, "had": true, "not": true, "been": true, "no": true,
+	"shall": true, "such": true, "any": true, "each": true, "which": true,
+	"their": true, "if": true, "than": true, "other": true, "into": true,
+	"may": true, "all": true, "who": true, "when": true, "upon": true,
+}
+
+func tokenize(text string) []string {
+	raw := strings.Fields(strings.ToLower(text))
+	out := make([]string, 0, len(raw))
+	for _, w := range raw {
+		w = strings.Trim(w, ".,;:!?\"'()[]{}*#>_\\-/")
+		if len(w) < 2 || stopWords[w] {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+type idfTable struct {
+	idf      map[string]float32
+	numDocs  int
+	defaultW float32
+}
+
+func computeIDF(chunks []string) *idfTable {
+	df := make(map[string]int)
+	for _, chunk := range chunks {
+		seen := make(map[string]bool)
+		for _, w := range tokenize(chunk) {
+			if !seen[w] {
+				df[w]++
+				seen[w] = true
+			}
+		}
+	}
+	n := float64(len(chunks))
+	idf := make(map[string]float32, len(df))
+	for word, count := range df {
+		idf[word] = float32(math.Log(n / float64(count)))
+	}
+	return &idfTable{
+		idf:      idf,
+		numDocs:  len(chunks),
+		defaultW: float32(math.Log(n)),
+	}
+}
+
+func (t *idfTable) weight(word string) float32 {
+	if w, ok := t.idf[word]; ok {
+		return w
+	}
+	return t.defaultW
+}
+
+func wordHash(word string, dims int) (int, float32) {
+	h := fnv.New64a()
+	h.Write([]byte(word))
+	hash := h.Sum64()
+	idx := int(hash % uint64(dims))
+	sign := float32(1.0)
+	if hash&(1<<32) != 0 {
+		sign = -1.0
+	}
+	return idx, sign
+}
+
+// tfidfEmbedding produces a TF-IDF weighted feature-hashed embedding.
+// Stop words are removed; each remaining word hashes to a dimension index,
+// weighted by IDF. Shared words create direct cosine similarity signal.
+func tfidfEmbedding(text string, dims int, idf *idfTable) hnsw.Vector {
+	vec := make(hnsw.Vector, dims)
+	words := tokenize(text)
+	if len(words) == 0 {
+		return vec
+	}
+	for _, word := range words {
+		w := idf.weight(word)
+		idx, sign := wordHash(word, dims)
+		vec[idx] += sign * w
+	}
+	var norm float32
+	for _, v := range vec {
+		norm += v * v
+	}
+	norm = float32(math.Sqrt(float64(norm)))
+	if norm > 0 {
+		for i := range vec {
+			vec[i] /= norm
+		}
+	}
+	return vec
+}

--- a/graph.go
+++ b/graph.go
@@ -64,7 +64,7 @@ func (n *layerNode[K]) addNeighbor(newNode *layerNode[K], m int, dist DistanceFu
 	delete(n.neighbors, worst.Key)
 	// Delete backlink from the worst neighbor.
 	delete(worst.neighbors, n.Key)
-	worst.replenish(m)
+	worst.replenish(m, dist)
 }
 
 type searchCandidate[K cmp.Ordered] struct {
@@ -106,24 +106,26 @@ func (n *layerNode[K]) search(
 	visited[n.Key] = true
 
 	for candidates.Len() > 0 {
-		var (
-			current  = candidates.Pop().node
-			improved = false
-		)
+		current := candidates.Pop()
+
+		// Standard HNSW termination: if the closest remaining candidate
+		// is farther than the worst result, no further improvement is possible.
+		if result.Len() >= k && current.dist > result.Max().dist {
+			break
+		}
 
 		// We iterate the map in a sorted, deterministic fashion for
 		// tests.
-		neighborKeys := maps.Keys(current.neighbors)
+		neighborKeys := maps.Keys(current.node.neighbors)
 		slices.Sort(neighborKeys)
 		for _, neighborID := range neighborKeys {
-			neighbor := current.neighbors[neighborID]
+			neighbor := current.node.neighbors[neighborID]
 			if visited[neighborID] {
 				continue
 			}
 			visited[neighborID] = true
 
 			dist := distance(neighbor.Value, target)
-			improved = improved || dist < result.Min().dist
 			if result.Len() < k {
 				result.Push(searchCandidate[K]{node: neighbor, dist: dist})
 			} else if dist < result.Max().dist {
@@ -132,23 +134,16 @@ func (n *layerNode[K]) search(
 			}
 
 			candidates.Push(searchCandidate[K]{node: neighbor, dist: dist})
-			// Always store candidates if we haven't reached the limit.
 			if candidates.Len() > efSearch {
 				candidates.PopLast()
 			}
-		}
-
-		// Termination condition: no improvement in distance and at least
-		// kMin candidates in the result set.
-		if !improved && result.Len() >= k {
-			break
 		}
 	}
 
 	return result.Slice()
 }
 
-func (n *layerNode[K]) replenish(m int) {
+func (n *layerNode[K]) replenish(m int, dist DistanceFunc) {
 	if len(n.neighbors) >= m {
 		return
 	}
@@ -165,7 +160,7 @@ func (n *layerNode[K]) replenish(m int) {
 			if candidate == n {
 				continue
 			}
-			n.addNeighbor(candidate, m, CosineDistance)
+			n.addNeighbor(candidate, m, dist)
 			if len(n.neighbors) >= m {
 				return
 			}
@@ -175,13 +170,13 @@ func (n *layerNode[K]) replenish(m int) {
 
 // isolates remove the node from the graph by removing all connections
 // to neighbors.
-func (n *layerNode[K]) isolate(m int) {
+func (n *layerNode[K]) isolate(m int, dist DistanceFunc) {
 	for _, neighbor := range n.neighbors {
 		delete(neighbor.neighbors, n.Key)
 	}
 
 	for _, neighbor := range n.neighbors {
-		neighbor.replenish(m)
+		neighbor.replenish(m, dist)
 	}
 }
 
@@ -370,9 +365,12 @@ func (g *Graph[K]) Add(nodes ...Node[K]) {
 			searchPoint := layer.entry()
 
 			// On subsequent layers, we use the elevator node to enter the graph
-			// at the best point.
+			// at the best point. The elevator may have been deleted between
+			// layers, so guard with an existence check.
 			if elevator != nil {
-				searchPoint = layer.nodes[*elevator]
+				if node, ok := layer.nodes[*elevator]; ok {
+					searchPoint = node
+				}
 			}
 
 			if g.Distance == nil {
@@ -447,8 +445,12 @@ func (h *Graph[K]) search(near Vector, k int) []SearchResult[K] {
 
 	for layer := len(h.layers) - 1; layer >= 0; layer-- {
 		searchPoint := h.layers[layer].entry()
+		// The elevator may reference a node deleted between layers,
+		// so guard with an existence check.
 		if elevator != nil {
-			searchPoint = h.layers[layer].nodes[*elevator]
+			if node, ok := h.layers[layer].nodes[*elevator]; ok {
+				searchPoint = node
+			}
 		}
 
 		// Descending hierarchies
@@ -501,7 +503,7 @@ func (h *Graph[K]) Delete(key K) bool {
 		if len(layer.nodes) == 0 {
 			deleteLayer[i] = struct{}{}
 		}
-		node.isolate(h.M)
+		node.isolate(h.M, h.Distance)
 		deleted = true
 	}
 

--- a/graph.go
+++ b/graph.go
@@ -79,14 +79,15 @@ func (s searchCandidate[K]) Less(o searchCandidate[K]) bool {
 // search returns the layer node closest to the target node
 // within the same layer.
 func (n *layerNode[K]) search(
-	// k is the number of candidates in the result set.
+	// k is the number of nearest neighbors to return.
 	k int,
 	efSearch int,
 	target Vector,
 	distance DistanceFunc,
 ) []searchCandidate[K] {
-	// This is a basic greedy algorithm to find the entry point at the given level
-	// that is closest to the target node.
+	// HNSW paper Algorithm 5 (SEARCH-LAYER).
+	// The result set W is bounded by efSearch (not k) to prevent premature
+	// termination. Only the k closest are returned after the search completes.
 	candidates := heap.Heap[searchCandidate[K]]{}
 	candidates.Init(make([]searchCandidate[K], 0, efSearch))
 	candidates.Push(
@@ -99,7 +100,7 @@ func (n *layerNode[K]) search(
 		result  = heap.Heap[searchCandidate[K]]{}
 		visited = make(map[K]bool)
 	)
-	result.Init(make([]searchCandidate[K], 0, k))
+	result.Init(make([]searchCandidate[K], 0, efSearch))
 
 	// Begin with the entry node in the result set.
 	result.Push(candidates.Min())
@@ -109,8 +110,9 @@ func (n *layerNode[K]) search(
 		current := candidates.Pop()
 
 		// Standard HNSW termination: if the closest remaining candidate
-		// is farther than the worst result, no further improvement is possible.
-		if result.Len() >= k && current.dist > result.Max().dist {
+		// is farther than the worst in the ef-bounded result set,
+		// no further improvement is possible.
+		if result.Len() >= efSearch && current.dist > result.Max().dist {
 			break
 		}
 
@@ -126,21 +128,32 @@ func (n *layerNode[K]) search(
 			visited[neighborID] = true
 
 			dist := distance(neighbor.Value, target)
-			if result.Len() < k {
+			if result.Len() < efSearch {
 				result.Push(searchCandidate[K]{node: neighbor, dist: dist})
+				candidates.Push(searchCandidate[K]{node: neighbor, dist: dist})
 			} else if dist < result.Max().dist {
 				result.PopLast()
 				result.Push(searchCandidate[K]{node: neighbor, dist: dist})
-			}
-
-			candidates.Push(searchCandidate[K]{node: neighbor, dist: dist})
-			if candidates.Len() > efSearch {
-				candidates.PopLast()
+				candidates.Push(searchCandidate[K]{node: neighbor, dist: dist})
 			}
 		}
 	}
 
-	return result.Slice()
+	// Return only the k closest from the ef-sized result set.
+	res := result.Slice()
+	slices.SortFunc(res, func(a, b searchCandidate[K]) int {
+		if a.dist < b.dist {
+			return -1
+		}
+		if a.dist > b.dist {
+			return 1
+		}
+		return cmp.Compare(a.node.Key, b.node.Key)
+	})
+	if len(res) > k {
+		res = res[:k]
+	}
+	return res
 }
 
 func (n *layerNode[K]) replenish(m int, dist DistanceFunc) {

--- a/graph_test.go
+++ b/graph_test.go
@@ -118,8 +118,8 @@ func TestGraph_AddSearch(t *testing.T) {
 		[]Node[int]{
 			{64, Vector{64}},
 			{65, Vector{65}},
-			{62, Vector{62}},
 			{63, Vector{63}},
+			{66, Vector{66}},
 		},
 		nearest,
 	)
@@ -258,4 +258,210 @@ func TestGraph_RemoveAllNodes(t *testing.T) {
 		g.Delete(1)
 		g.Add(MakeNode(1, vec))
 	}
+}
+
+func TestGraph_SearchWithDistance(t *testing.T) {
+	g := newTestGraph[int]()
+	for i := 0; i < 10; i++ {
+		g.Add(Node[int]{Key: i, Value: Vector{float32(i)}})
+	}
+
+	results := g.SearchWithDistance([]float32{5.5}, 3)
+	require.Len(t, results, 3)
+
+	// Distances should be non-negative
+	for _, r := range results {
+		require.GreaterOrEqual(t, r.Distance, float32(0))
+	}
+
+	// All nearest neighbors should be close to 5.5
+	for _, r := range results {
+		require.LessOrEqual(t, r.Distance, float32(3),
+			"node %d should be close to query", r.Node.Key)
+	}
+}
+
+func TestGraph_Lookup(t *testing.T) {
+	g := newTestGraph[int]()
+	g.Add(Node[int]{Key: 42, Value: Vector{1.0, 2.0, 3.0}})
+
+	vec, ok := g.Lookup(42)
+	require.True(t, ok)
+	require.Equal(t, Vector{1.0, 2.0, 3.0}, vec)
+}
+
+func TestGraph_Lookup_NotFound(t *testing.T) {
+	g := newTestGraph[int]()
+	g.Add(Node[int]{Key: 1, Value: Vector{1.0}})
+
+	vec, ok := g.Lookup(999)
+	require.False(t, ok)
+	require.Nil(t, vec)
+}
+
+func TestGraph_Lookup_EmptyGraph(t *testing.T) {
+	g := newTestGraph[int]()
+
+	vec, ok := g.Lookup(1)
+	require.False(t, ok)
+	require.Nil(t, vec)
+}
+
+func TestGraph_Search_EmptyGraph(t *testing.T) {
+	g := newTestGraph[int]()
+
+	results := g.Search([]float32{1.0}, 5)
+	require.Empty(t, results)
+}
+
+func TestGraph_Delete_EmptyGraph(t *testing.T) {
+	g := newTestGraph[int]()
+
+	ok := g.Delete(1)
+	require.False(t, ok)
+}
+
+func TestGraph_Dims(t *testing.T) {
+	g := newTestGraph[int]()
+
+	// Empty graph has 0 dims
+	require.Equal(t, 0, g.Dims())
+
+	g.Add(Node[int]{Key: 1, Value: Vector{1.0, 2.0, 3.0}})
+	require.Equal(t, 3, g.Dims())
+}
+
+func TestGraph_Len(t *testing.T) {
+	g := newTestGraph[int]()
+	require.Equal(t, 0, g.Len())
+
+	g.Add(Node[int]{Key: 1, Value: Vector{1.0}})
+	require.Equal(t, 1, g.Len())
+
+	g.Add(Node[int]{Key: 2, Value: Vector{2.0}})
+	require.Equal(t, 2, g.Len())
+
+	g.Delete(1)
+	require.Equal(t, 1, g.Len())
+}
+
+func TestGraph_AddReplace(t *testing.T) {
+	g := newTestGraph[int]()
+	// Add several nodes first so the graph has structure
+	for i := 0; i < 10; i++ {
+		g.Add(Node[int]{Key: i, Value: Vector{float32(i)}})
+	}
+	require.Equal(t, 10, g.Len())
+
+	// Replace node 5 with a new value
+	g.Add(Node[int]{Key: 5, Value: Vector{99.0}})
+	require.Equal(t, 10, g.Len())
+
+	vec, ok := g.Lookup(5)
+	require.True(t, ok)
+	require.Equal(t, Vector{99.0}, vec)
+}
+
+func TestGraph_DeleteWithEuclidean(t *testing.T) {
+	// Regression test for the replenish() bug where CosineDistance was
+	// hardcoded instead of using the graph's configured distance function.
+	g := &Graph[int]{
+		M:        4,
+		Distance: EuclideanDistance,
+		Ml:       0.5,
+		EfSearch: 20,
+		Rng:      rand.New(rand.NewSource(42)),
+	}
+
+	// Add enough nodes to trigger replenish on delete
+	for i := 0; i < 32; i++ {
+		g.Add(Node[int]{Key: i, Value: Vector{float32(i * 10)}})
+	}
+
+	// Delete a middle node — should trigger isolate → replenish with EuclideanDistance
+	ok := g.Delete(16)
+	require.True(t, ok)
+
+	// Graph should still be searchable with correct results
+	nearest := g.Search([]float32{160}, 3)
+	require.NotEmpty(t, nearest)
+
+	// Verify the nearest results make sense for Euclidean distance
+	for _, n := range nearest {
+		dist := EuclideanDistance(n.Value, Vector{160})
+		require.LessOrEqual(t, dist, float32(30),
+			"node %d (value %v) is too far from query", n.Key, n.Value)
+	}
+}
+
+func TestGraph_DeleteWithCosine(t *testing.T) {
+	g := NewGraph[int]()
+	g.Rng = rand.New(rand.NewSource(42))
+
+	// Add normalized-ish vectors
+	g.Add(
+		Node[int]{Key: 1, Value: Vector{1, 0}},
+		Node[int]{Key: 2, Value: Vector{0.9, 0.1}},
+		Node[int]{Key: 3, Value: Vector{0, 1}},
+		Node[int]{Key: 4, Value: Vector{0.5, 0.5}},
+		Node[int]{Key: 5, Value: Vector{0.7, 0.3}},
+	)
+
+	ok := g.Delete(2)
+	require.True(t, ok)
+
+	// Search should still work correctly
+	nearest := g.Search([]float32{1, 0}, 2)
+	require.Len(t, nearest, 2)
+	require.Equal(t, 1, nearest[0].Key)
+}
+
+func TestGraph_StaleElevator(t *testing.T) {
+	// Regression test for upstream issue #15: panic when elevator node
+	// is deleted between layers.
+	g := &Graph[int]{
+		M:        4,
+		Distance: EuclideanDistance,
+		Ml:       0.5,
+		EfSearch: 20,
+		Rng:      rand.New(rand.NewSource(0)),
+	}
+
+	// Build a multi-layer graph
+	for i := 0; i < 64; i++ {
+		g.Add(Node[int]{Key: i, Value: Vector{float32(i)}})
+	}
+
+	al := Analyzer[int]{Graph: g}
+	require.Greater(t, al.Height(), 1, "need multiple layers for this test")
+
+	// Delete nodes that appear in upper layers, then add and search
+	// This should not panic.
+	for i := 60; i < 64; i++ {
+		g.Delete(i)
+	}
+
+	// Add new nodes after deletion — should not panic
+	for i := 100; i < 110; i++ {
+		g.Add(Node[int]{Key: i, Value: Vector{float32(i)}})
+	}
+
+	// Search should not panic
+	results := g.Search([]float32{50}, 5)
+	require.NotEmpty(t, results)
+}
+
+func TestGraph_assertDims_Panic(t *testing.T) {
+	g := newTestGraph[int]()
+	g.Add(Node[int]{Key: 1, Value: Vector{1.0, 2.0}})
+
+	require.Panics(t, func() {
+		g.Add(Node[int]{Key: 2, Value: Vector{1.0, 2.0, 3.0}})
+	})
+}
+
+func TestGraph_MakeNode(t *testing.T) {
+	n := MakeNode(42, Vector{1.0, 2.0})
+	require.Equal(t, 42, n.Key)
+	require.Equal(t, Vector{1.0, 2.0}, n.Value)
 }

--- a/heap/heap.go
+++ b/heap/heap.go
@@ -70,8 +70,10 @@ func (h *Heap[T]) Pop() T {
 	return heap.Pop(&h.inner).(T)
 }
 
+// PopLast removes and returns the maximum element from the heap.
 func (h *Heap[T]) PopLast() T {
-	return h.Remove(h.Len() - 1)
+	idx := h.maxIndex()
+	return h.Remove(idx)
 }
 
 // Remove removes and returns the element at index i from the heap.
@@ -85,9 +87,23 @@ func (h *Heap[T]) Min() T {
 	return h.inner.data[0]
 }
 
+// maxIndex returns the index of the maximum element by scanning leaf nodes.
+// In a min-heap the max is always a leaf (indices n/2 .. n-1).
+// Heaps in this library are small (bounded by M or EfSearch), so linear scan is fine.
+func (h *Heap[T]) maxIndex() int {
+	n := h.inner.Len()
+	best := n / 2
+	for i := best + 1; i < n; i++ {
+		if h.inner.data[best].Less(h.inner.data[i]) {
+			best = i
+		}
+	}
+	return best
+}
+
 // Max returns the maximum element in the heap.
 func (h *Heap[T]) Max() T {
-	return h.inner.data[h.inner.Len()-1]
+	return h.inner.data[h.maxIndex()]
 }
 
 func (h *Heap[T]) Slice() []T {

--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -32,3 +32,149 @@ func TestHeap(t *testing.T) {
 		t.Errorf("Heap did not return sorted elements: %+v", inOrder)
 	}
 }
+
+func TestHeap_Max(t *testing.T) {
+	h := Heap[Int]{}
+	values := []Int{5, 1, 9, 3, 7, 2, 8, 4, 6}
+	for _, v := range values {
+		h.Push(v)
+	}
+
+	require.Equal(t, Int(9), h.Max(), "Max should return the largest element")
+	require.Equal(t, Int(1), h.Min(), "Min should return the smallest element")
+}
+
+func TestHeap_Max_SingleElement(t *testing.T) {
+	h := Heap[Int]{}
+	h.Push(Int(42))
+	require.Equal(t, Int(42), h.Max())
+	require.Equal(t, Int(42), h.Min())
+}
+
+func TestHeap_Max_TwoElements(t *testing.T) {
+	h := Heap[Int]{}
+	h.Push(Int(10))
+	h.Push(Int(20))
+	require.Equal(t, Int(20), h.Max())
+	require.Equal(t, Int(10), h.Min())
+}
+
+func TestHeap_Max_DuplicateValues(t *testing.T) {
+	h := Heap[Int]{}
+	for i := 0; i < 5; i++ {
+		h.Push(Int(7))
+	}
+	require.Equal(t, Int(7), h.Max())
+	require.Equal(t, Int(7), h.Min())
+}
+
+func TestHeap_PopLast(t *testing.T) {
+	h := Heap[Int]{}
+	values := []Int{5, 1, 9, 3, 7, 2, 8, 4, 6}
+	for _, v := range values {
+		h.Push(v)
+	}
+
+	// PopLast should remove and return the maximum
+	got := h.PopLast()
+	require.Equal(t, Int(9), got)
+	require.Equal(t, 8, h.Len())
+
+	// Next max should be 8
+	got = h.PopLast()
+	require.Equal(t, Int(8), got)
+	require.Equal(t, 7, h.Len())
+
+	// Drain via PopLast — should come out in descending order
+	var descending []Int
+	descending = append(descending, got)
+	for h.Len() > 0 {
+		descending = append(descending, h.PopLast())
+	}
+	for i := 1; i < len(descending); i++ {
+		require.GreaterOrEqual(t, int(descending[i-1]), int(descending[i]),
+			"PopLast should return elements in descending order")
+	}
+}
+
+func TestHeap_PopLast_PreservesHeapInvariant(t *testing.T) {
+	h := Heap[Int]{}
+	for i := 0; i < 20; i++ {
+		h.Push(Int(rand.Intn(100)))
+	}
+
+	// Remove the max, then verify Pop still returns sorted
+	h.PopLast()
+
+	var inOrder []Int
+	for h.Len() > 0 {
+		inOrder = append(inOrder, h.Pop())
+	}
+	require.True(t, slices.IsSorted(inOrder), "Heap invariant broken after PopLast: %v", inOrder)
+}
+
+func TestHeap_Init(t *testing.T) {
+	data := []Int{5, 1, 9, 3, 7}
+	h := Heap[Int]{}
+	h.Init(data)
+
+	require.Equal(t, 5, h.Len())
+	require.Equal(t, Int(1), h.Min())
+	require.Equal(t, Int(9), h.Max())
+
+	var inOrder []Int
+	for h.Len() > 0 {
+		inOrder = append(inOrder, h.Pop())
+	}
+	require.True(t, slices.IsSorted(inOrder))
+}
+
+func TestHeap_Remove(t *testing.T) {
+	h := Heap[Int]{}
+	values := []Int{5, 1, 9, 3, 7}
+	for _, v := range values {
+		h.Push(v)
+	}
+
+	// Remove element at index 0 (the min)
+	got := h.Remove(0)
+	require.Equal(t, Int(1), got)
+	require.Equal(t, 4, h.Len())
+
+	// Remaining should still be a valid heap
+	var inOrder []Int
+	for h.Len() > 0 {
+		inOrder = append(inOrder, h.Pop())
+	}
+	require.True(t, slices.IsSorted(inOrder))
+	require.Equal(t, []Int{3, 5, 7, 9}, inOrder)
+}
+
+func TestHeap_Slice(t *testing.T) {
+	h := Heap[Int]{}
+	h.Push(Int(3))
+	h.Push(Int(1))
+	h.Push(Int(2))
+
+	s := h.Slice()
+	require.Equal(t, 3, len(s))
+	// First element should be the min (heap property)
+	require.Equal(t, Int(1), s[0])
+}
+
+func TestHeap_MaxCorrectnessStress(t *testing.T) {
+	// Verify Max() is correct across many random configurations
+	for trial := 0; trial < 100; trial++ {
+		h := Heap[Int]{}
+		n := rand.Intn(20) + 1
+		var maxVal Int
+		for i := 0; i < n; i++ {
+			v := Int(rand.Intn(1000))
+			h.Push(v)
+			if i == 0 || v > maxVal {
+				maxVal = v
+			}
+		}
+		require.Equal(t, maxVal, h.Max(), "trial %d: Max incorrect for heap of size %d", trial, n)
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,447 @@
+package hnsw
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	embeddingDim  = 2048
+	chunkMaxChars = 600
+)
+
+// chunkText splits text into chunks of roughly maxChars characters,
+// breaking at paragraph boundaries (double newline).
+func chunkText(text string, maxChars int) []string {
+	paragraphs := strings.Split(text, "\n\n")
+	var chunks []string
+	var current strings.Builder
+
+	for _, p := range paragraphs {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if current.Len() > 0 && current.Len()+len(p)+2 > maxChars {
+			chunks = append(chunks, current.String())
+			current.Reset()
+		}
+		if current.Len() > 0 {
+			current.WriteString("\n\n")
+		}
+		current.WriteString(p)
+	}
+	if current.Len() > 0 {
+		chunks = append(chunks, current.String())
+	}
+	return chunks
+}
+
+// wordHash returns a (dimension index, sign) pair for a word.
+// This is the "hashing trick" — each word deterministically maps to one
+// dimension, so shared words between query and document create direct
+// overlap in the vector, unlike random word vectors.
+func wordHash(word string, dims int) (int, float32) {
+	h := fnv.New64a()
+	h.Write([]byte(word))
+	hash := h.Sum64()
+	idx := int(hash % uint64(dims))
+	sign := float32(1.0)
+	if hash&(1<<32) != 0 {
+		sign = -1.0
+	}
+	return idx, sign
+}
+
+// stopWords are common English words that carry little discriminating value.
+// Removing them lets rare, meaningful words dominate the embedding.
+var stopWords = map[string]bool{
+	"a": true, "an": true, "and": true, "are": true, "as": true, "at": true,
+	"be": true, "by": true, "for": true, "from": true, "has": true, "he": true,
+	"in": true, "is": true, "it": true, "its": true, "of": true, "on": true,
+	"or": true, "that": true, "the": true, "to": true, "was": true, "were": true,
+	"will": true, "with": true, "this": true, "but": true, "they": true,
+	"have": true, "had": true, "not": true, "been": true, "no": true,
+	"shall": true, "such": true, "any": true, "each": true, "which": true,
+	"their": true, "if": true, "than": true, "other": true, "into": true,
+	"may": true, "all": true, "who": true, "when": true, "upon": true,
+}
+
+// tokenize splits text into lowercase words with stop words removed.
+func tokenize(text string) []string {
+	raw := strings.Fields(strings.ToLower(text))
+	out := make([]string, 0, len(raw))
+	for _, w := range raw {
+		// Strip common markdown/punctuation from edges
+		w = strings.Trim(w, ".,;:!?\"'()[]{}*#>_\\-/")
+		if len(w) < 2 || stopWords[w] {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+// idfTable holds inverse document frequency weights computed from a corpus.
+// Words that appear in many documents get low weight; rare words get high weight.
+type idfTable struct {
+	idf      map[string]float32
+	numDocs  int
+	defaultW float32 // weight for unseen words (max IDF)
+}
+
+// buildIDF computes IDF weights from a set of text chunks.
+// IDF(word) = log(N / df(word)) where df is the number of chunks containing the word.
+func buildIDF(chunks []string) *idfTable {
+	df := make(map[string]int)
+	for _, chunk := range chunks {
+		seen := make(map[string]bool)
+		for _, w := range tokenize(chunk) {
+			if !seen[w] {
+				df[w]++
+				seen[w] = true
+			}
+		}
+	}
+
+	n := float64(len(chunks))
+	idf := make(map[string]float32, len(df))
+	for word, count := range df {
+		idf[word] = float32(math.Log(n / float64(count)))
+	}
+
+	return &idfTable{
+		idf:      idf,
+		numDocs:  len(chunks),
+		defaultW: float32(math.Log(n)), // max possible IDF for unseen words
+	}
+}
+
+func (t *idfTable) weight(word string) float32 {
+	if w, ok := t.idf[word]; ok {
+		return w
+	}
+	return t.defaultW
+}
+
+// tfidfEmbedding produces a TF-IDF weighted feature-hashed embedding.
+// Stop words are removed. Each remaining word hashes to a dimension index
+// (the "hashing trick"), weighted by its IDF score. Shared words between
+// query and document contribute to the SAME dimensions, creating direct
+// cosine similarity signal — unlike random word vectors where shared words
+// contribute to unrelated directions.
+func tfidfEmbedding(text string, dims int, idf *idfTable) Vector {
+	vec := make(Vector, dims)
+	words := tokenize(text)
+	if len(words) == 0 {
+		return vec
+	}
+
+	for _, word := range words {
+		w := idf.weight(word)
+		idx, sign := wordHash(word, dims)
+		vec[idx] += sign * w
+	}
+
+	// L2 normalize
+	var norm float32
+	for _, v := range vec {
+		norm += v * v
+	}
+	norm = float32(math.Sqrt(float64(norm)))
+	if norm > 0 {
+		for i := range vec {
+			vec[i] /= norm
+		}
+	}
+	return vec
+}
+
+// bruteForceKNN returns the k nearest neighbors by exhaustive search.
+func bruteForceKNN(query Vector, nodes []Node[string], k int, dist DistanceFunc) []Node[string] {
+	type scored struct {
+		node Node[string]
+		dist float32
+	}
+	results := make([]scored, len(nodes))
+	for i, n := range nodes {
+		results[i] = scored{node: n, dist: dist(query, n.Value)}
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].dist < results[j].dist
+	})
+	if k > len(results) {
+		k = len(results)
+	}
+	out := make([]Node[string], k)
+	for i := 0; i < k; i++ {
+		out[i] = results[i].node
+	}
+	return out
+}
+
+// recallAtK computes the fraction of ground-truth results found in predicted.
+func recallAtK(predicted, groundTruth []Node[string]) float64 {
+	truthSet := make(map[string]struct{}, len(groundTruth))
+	for _, n := range groundTruth {
+		truthSet[n.Key] = struct{}{}
+	}
+	var hits int
+	for _, n := range predicted {
+		if _, ok := truthSet[n.Key]; ok {
+			hits++
+		}
+	}
+	return float64(hits) / float64(len(groundTruth))
+}
+
+func loadTestDocuments(t *testing.T) []Node[string] {
+	t.Helper()
+	files, err := filepath.Glob("test-data/*.md")
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "no test documents found in test-data/")
+
+	// First pass: collect all chunks to build IDF table
+	type docChunk struct {
+		docName string
+		index   int
+		text    string
+	}
+	var allChunks []docChunk
+	var allTexts []string
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		require.NoError(t, err)
+		docName := strings.TrimSuffix(filepath.Base(f), ".md")
+		chunks := chunkText(string(data), chunkMaxChars)
+		for i, chunk := range chunks {
+			allChunks = append(allChunks, docChunk{docName, i, chunk})
+			allTexts = append(allTexts, chunk)
+		}
+	}
+
+	idf := buildIDF(allTexts)
+
+	// Second pass: embed with TF-IDF weights
+	var nodes []Node[string]
+	for _, dc := range allChunks {
+		key := fmt.Sprintf("%s:%d", dc.docName, dc.index)
+		nodes = append(nodes, Node[string]{
+			Key:   key,
+			Value: tfidfEmbedding(dc.text, embeddingDim, idf),
+		})
+	}
+	return nodes
+}
+
+func TestIntegration_ConstitutionSearch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	nodes := loadTestDocuments(t)
+	require.Greater(t, len(nodes), 50, "expected substantial number of chunks")
+
+	g := &Graph[string]{
+		M:        16,
+		Ml:       0.25,
+		Distance: CosineDistance,
+		EfSearch: 100,
+		Rng:      rand.New(rand.NewSource(42)),
+	}
+
+	for _, n := range nodes {
+		g.Add(n)
+	}
+	require.Equal(t, len(nodes), g.Len())
+
+	// Test recall against brute-force ground truth
+	ks := []int{5, 10, 20}
+	// Use a set of query nodes from the corpus itself
+	queryIndices := []int{0, len(nodes) / 4, len(nodes) / 2, 3 * len(nodes) / 4, len(nodes) - 1}
+
+	for _, k := range ks {
+		var totalRecall float64
+		var nQueries int
+		for _, qi := range queryIndices {
+			query := nodes[qi].Value
+			hnswResults := g.Search(query, k)
+			bfResults := bruteForceKNN(query, nodes, k, CosineDistance)
+			recall := recallAtK(hnswResults, bfResults)
+			totalRecall += recall
+			nQueries++
+		}
+		avgRecall := totalRecall / float64(nQueries)
+		t.Logf("recall@%d: %.2f (averaged over %d queries)", k, avgRecall, nQueries)
+		require.GreaterOrEqual(t, avgRecall, 0.6,
+			"recall@%d too low: %.2f", k, avgRecall)
+	}
+}
+
+func TestIntegration_ConstitutionDeleteAndSearch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	nodes := loadTestDocuments(t)
+
+	g := &Graph[string]{
+		M:        16,
+		Ml:       0.25,
+		Distance: CosineDistance,
+		EfSearch: 100,
+		Rng:      rand.New(rand.NewSource(42)),
+	}
+
+	for _, n := range nodes {
+		g.Add(n)
+	}
+
+	preLen := g.Len()
+
+	// Delete 20% of nodes
+	rng := rand.New(rand.NewSource(99))
+	deleteCount := preLen / 5
+	perm := rng.Perm(len(nodes))
+	deletedKeys := make(map[string]struct{})
+	for i := 0; i < deleteCount; i++ {
+		key := nodes[perm[i]].Key
+		ok := g.Delete(key)
+		require.True(t, ok)
+		deletedKeys[key] = struct{}{}
+	}
+
+	require.Equal(t, preLen-deleteCount, g.Len())
+
+	// Build surviving nodes list for brute-force
+	var surviving []Node[string]
+	for _, n := range nodes {
+		if _, deleted := deletedKeys[n.Key]; !deleted {
+			surviving = append(surviving, n)
+		}
+	}
+
+	// Search should still work and find reasonable results
+	query := surviving[0].Value
+	hnswResults := g.Search(query, 10)
+	bfResults := bruteForceKNN(query, surviving, 10, CosineDistance)
+	recall := recallAtK(hnswResults, bfResults)
+	t.Logf("recall@10 after 20%% deletion: %.2f", recall)
+	require.GreaterOrEqual(t, recall, 0.5,
+		"recall degraded too much after deletion")
+
+	// Check graph connectivity
+	al := Analyzer[string]{Graph: g}
+	connectivity := al.Connectivity()
+	require.NotEmpty(t, connectivity)
+	t.Logf("post-delete connectivity: %v", connectivity)
+	// Base layer should still have some connectivity
+	require.Greater(t, connectivity[0], float64(0),
+		"base layer lost all connectivity")
+}
+
+func TestIntegration_ConstitutionExportImport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	nodes := loadTestDocuments(t)
+
+	g := &Graph[string]{
+		M:        16,
+		Ml:       0.25,
+		Distance: CosineDistance,
+		EfSearch: 100,
+		Rng:      rand.New(rand.NewSource(42)),
+	}
+	for _, n := range nodes {
+		g.Add(n)
+	}
+
+	// Export and reimport
+	dir := t.TempDir()
+	sg := &SavedGraph[string]{Graph: g, Path: filepath.Join(dir, "constitution.idx")}
+	err := sg.Save()
+	require.NoError(t, err)
+
+	sg2, err := LoadSavedGraph[string](filepath.Join(dir, "constitution.idx"))
+	require.NoError(t, err)
+	require.Equal(t, g.Len(), sg2.Len())
+
+	// Search results should match between original and imported
+	query := nodes[0].Value
+	r1 := g.Search(query, 5)
+	r2 := sg2.Search(query, 5)
+	require.Equal(t, r1, r2)
+}
+
+func BenchmarkIntegration_Constitution(b *testing.B) {
+	files, _ := filepath.Glob("test-data/*.md")
+	if len(files) == 0 {
+		b.Skip("no test data")
+	}
+
+	var allTexts []string
+	type dc struct {
+		name  string
+		index int
+		text  string
+	}
+	var allChunks []dc
+	for _, f := range files {
+		data, _ := os.ReadFile(f)
+		docName := strings.TrimSuffix(filepath.Base(f), ".md")
+		chunks := chunkText(string(data), chunkMaxChars)
+		for i, chunk := range chunks {
+			allChunks = append(allChunks, dc{docName, i, chunk})
+			allTexts = append(allTexts, chunk)
+		}
+	}
+	idf := buildIDF(allTexts)
+	var allNodes []Node[string]
+	for _, c := range allChunks {
+		key := fmt.Sprintf("%s:%d", c.name, c.index)
+		allNodes = append(allNodes, Node[string]{
+			Key:   key,
+			Value: tfidfEmbedding(c.text, embeddingDim, idf),
+		})
+	}
+
+	b.Run("Insert", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			g := &Graph[string]{
+				M: 16, Ml: 0.25, Distance: CosineDistance,
+				EfSearch: 100, Rng: rand.New(rand.NewSource(42)),
+			}
+			for _, n := range allNodes {
+				g.Add(n)
+			}
+		}
+	})
+
+	// Build once for search/delete benchmarks
+	g := &Graph[string]{
+		M: 16, Ml: 0.25, Distance: CosineDistance,
+		EfSearch: 100, Rng: rand.New(rand.NewSource(42)),
+	}
+	for _, n := range allNodes {
+		g.Add(n)
+	}
+
+	b.Run("Search", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			g.Search(allNodes[i%len(allNodes)].Value, 10)
+		}
+	})
+}

--- a/test-data/Canadian_Constitution_Act_1867.md
+++ b/test-data/Canadian_Constitution_Act_1867.md
@@ -1,0 +1,1599 @@
+---
+title: "Constitution Act, 1867"
+source: "https://primarydocuments.ca/constitution/"
+author:
+  - "[[PrimaryDocuments.ca]]"
+published: 2017-11-16
+created: 2026-04-08
+description: "(FORMERLY THE BRITISH NORTH AMERICA ACT, 1867) Table of Contents PREAMBLE I. PRELIMINARY (1-2) 1. Short Title 2. Application of Provisions Referring to the Queen II. UNION (3-8) 3. Declaration of Union 4. Construction of Subsequent Provisions of Act 5. Four Provinces 6. Provinces of Ontario and Quebec 7. Provinces of Nova Scotia and New…"
+tags:
+  - "clippings"
+---
+(FORMERLY THE BRITISH NORTH AMERICA ACT, 1867)
+
+---
+
+### Table of Contents
+
+**[PREAMBLE](https://primarydocuments.ca/constitution/#preamble)**
+
+**[I. PRELIMINARY (1-2)](https://primarydocuments.ca/constitution/#part-i)**  
+[1\. Short Title](https://primarydocuments.ca/constitution/#s-1)  
+[2\. Application of Provisions Referring to the Queen](https://primarydocuments.ca/constitution/#s-2)
+
+**[II. UNION (3-8)](https://primarydocuments.ca/constitution/#part-ii)**  
+[3\. Declaration of Union](https://primarydocuments.ca/constitution/#s-3)  
+[4\. Construction of Subsequent Provisions of Act](https://primarydocuments.ca/constitution/#s-4)  
+[5\. Four Provinces](https://primarydocuments.ca/constitution/#s-5)  
+[6\. Provinces of Ontario and Quebec](https://primarydocuments.ca/constitution/#s-6)  
+[7\. Provinces of Nova Scotia and New Brunswick](https://primarydocuments.ca/constitution/#s-7)  
+[8\. Decennial Census](https://primarydocuments.ca/constitution/#s-8)
+
+**[III. EXECUTIVE POWER (9-16)](https://primarydocuments.ca/constitution/#part-iii)**  
+[9\. Declaration of Executive Power in the Queen](https://primarydocuments.ca/constitution/#s-9)  
+[10\. Application of Provisions Referring to Governor-General  
+](https://primarydocuments.ca/constitution/#s-10)[11\. Constitution of Privy Council for Canada](https://primarydocuments.ca/constitution/#s-11)  
+[12\. All Powers Under Acts to Be Exercised By Governor-General with Advice of Privy Council, or Alone](https://primarydocuments.ca/constitution/#s-12)  
+[13\. Application of Provisions Referring to Governor General in Council](https://primarydocuments.ca/constitution/#s-13)  
+[14\. Power to Her Majesty to Authorize Governor General to Appoint Deputies](https://primarydocuments.ca/constitution/#s-14)  
+[15\. Command of Armed Forces to Continue to be Vested in the Queen](https://primarydocuments.ca/constitution/#s-15)  
+[16\. Seat of Government of Canada](https://primarydocuments.ca/constitution/#s-16)
+
+**[IV. LEGISLATIVE POWER (17-57)](https://primarydocuments.ca/constitution/#part-iv)**  
+[17\. Constitution of Parliament of Canada](https://primarydocuments.ca/constitution/#s-17)  
+[18\. Privileges, etc., of Houses](https://primarydocuments.ca/constitution/#s-18)  
+[19\. First Session of the Parliament of Canada](https://primarydocuments.ca/constitution/#s-19)  
+[20\. Yearly Session of the Parliament of Canada](https://primarydocuments.ca/constitution/#s-20)  
+[21\. Number of Senators](https://primarydocuments.ca/constitution/#s-21)  
+[22\. Representation of Provinces in Senate](https://primarydocuments.ca/constitution/#s-22)  
+[23\. Qualifications of Senator](https://primarydocuments.ca/constitution/#s-23)  
+[24\. Summons of Senator](https://primarydocuments.ca/constitution/#s-24)  
+[25\. Summons of First Body of Senators](https://primarydocuments.ca/constitution/#s-25)  
+[26\. Addition of Senators in certain Cases](https://primarydocuments.ca/constitution/#s-26)  
+[27\. Reduction of Senate to Normal Number](https://primarydocuments.ca/constitution/#s-27)  
+[28\. Maximum Number of Senators](https://primarydocuments.ca/constitution/#s-28)  
+[29\. (1)Tenure of Place in Senate](https://primarydocuments.ca/constitution/#s-29-1)  
+[29\. (2)Retirement Upon Attaining Age of Seventy-Five Years](https://primarydocuments.ca/constitution/#s-29-2)  
+[30\. Resignation of Place in Senate](https://primarydocuments.ca/constitution/#s-30)  
+[31\. Disqualification of Senators](https://primarydocuments.ca/constitution/#s-31)  
+[32\. Summons on Vacancy in Senate](https://primarydocuments.ca/constitution/#s-32)  
+[33\. Questions as to Qualifications and Vacancies in Senate](https://primarydocuments.ca/constitution/#s-33)  
+[34\. Appointment of Speaker of Senate](https://primarydocuments.ca/constitution/#s-34)  
+[35\. Quorum of Senate](https://primarydocuments.ca/constitution/#s-35)  
+[36\. Voting in Senate](https://primarydocuments.ca/constitution/#s-36)  
+[37\. Constitution of House of Commons in Canada](https://primarydocuments.ca/constitution/#s-37)  
+[38\. Summoning of House of Commons](https://primarydocuments.ca/constitution/#s-38)  
+[39\. Senators Not to Sit in House of Commons](https://primarydocuments.ca/constitution/#s-39)  
+[40\. Electoral Districts of the Four Provinces  
+](https://primarydocuments.ca/constitution/#s-40)[41\. Continuance of Existing Election Laws Until Parliament of Canada Otherwise Provides](https://primarydocuments.ca/constitution/#s-41)  
+[42\. Writs for First Election](https://primarydocuments.ca/constitution/#s-42)  
+[43\. As to Casual Vacancies](https://primarydocuments.ca/constitution/#s-43)  
+[44\. As to Election of Speaker of House of Commons](https://primarydocuments.ca/constitution/#s-44)  
+[45\. As to Filling Up Vacancy in Office of Speaker](https://primarydocuments.ca/constitution/#s-45)  
+[46\. Speaker to Preside](https://primarydocuments.ca/constitution/#s-46)  
+[47\. Provision in Case of Absence of Speaker](https://primarydocuments.ca/constitution/#s-47)  
+[48\. Quorum of House of Commons](https://primarydocuments.ca/constitution/#s-48)  
+[49\. Voting in House of Commons](https://primarydocuments.ca/constitution/#s-49)  
+[50\. Duration of House of Commons](https://primarydocuments.ca/constitution/#s-50)  
+[51\. Decennial Readjustment of Representation](https://primarydocuments.ca/constitution/#s-51)  
+[51.(1) Readjustment of Representation in Commons](https://primarydocuments.ca/constitution/#s-51-1)  
+[1-2. Rules](https://primarydocuments.ca/constitution/#s-51-1-2)  
+[(2) Yukon Territory and Northwest Territories](https://primarydocuments.ca/constitution/#s-51-2)  
+[51A. Constitution of House of Commons](https://primarydocuments.ca/constitution/#s-51a)  
+[52\. Increase of Number of House of Commons](https://primarydocuments.ca/constitution/#s-52)  
+[53\. Appropriation and Tax Bills](https://primarydocuments.ca/constitution/#s-53)  
+[54\. Recommendation of Money Votes](https://primarydocuments.ca/constitution/#s-54)  
+[55\. Royal Assent to Bills, etc.](https://primarydocuments.ca/constitution/#s-55)  
+[56\. Disallowance by Order in Council of Act Assented to By Governor General](https://primarydocuments.ca/constitution/#s-56)  
+[57\. Signification of Queen’s Pleasure on Bill Reserved](https://primarydocuments.ca/constitution/#s-57)
+
+**[V. PROVINCIAL CONSTITUTIONS (58-90)](https://primarydocuments.ca/constitution/#part-v)**  
+[58\. Appointment of Lieutenant Governors of Provinces](https://primarydocuments.ca/constitution/#s-58)  
+[59\. Tenure of Office of Lieutenant Governor](https://primarydocuments.ca/constitution/#s-59)  
+[60\. Salaries of Lieutenant Governors](https://primarydocuments.ca/constitution/#s-60)  
+[61\. Oaths, etc., of Lieutenant Governor](https://primarydocuments.ca/constitution/#s-61)  
+[62\. Application of Provisions Referring to Lieutenant Governor](https://primarydocuments.ca/constitution/#s-62)  
+[63\. Appointment of Executive Officers for Ontario and Quebec](https://primarydocuments.ca/constitution/#s-63)  
+[64\. Executive Government of Nova Scotia](https://primarydocuments.ca/constitution/#s-64)  
+[65\. Powers to be Exercised by Lieutenant Governor of Ontario or Quebec with Advice, or Alone](https://primarydocuments.ca/constitution/#s-65)  
+[66\. Application of Provisions Referring to Lieutenant Governor in Council](https://primarydocuments.ca/constitution/#s-66)  
+[67\. Administration in Absence, etc., of Lieutenant Governor](https://primarydocuments.ca/constitution/#s-67)  
+[68\. Seats of Provincial Governments](https://primarydocuments.ca/constitution/#s-68)  
+[69\. Legislature for Ontario](https://primarydocuments.ca/constitution/#s-69)  
+[70\. Electoral Districts](https://primarydocuments.ca/constitution/#s-70)  
+[71\. Legislature for Quebec](https://primarydocuments.ca/constitution/#s-71)  
+[72\. Constitution of Legislative Council](https://primarydocuments.ca/constitution/#s-72)  
+[73\. Qualification of Legislative Councillors](https://primarydocuments.ca/constitution/#s-73)  
+[74\. Resignation, Disqualification, etc.](https://primarydocuments.ca/constitution/#s-74)  
+[75\. Vacancies](https://primarydocuments.ca/constitution/#s-75)  
+[76\. Questions as to Vacancies, etc.](https://primarydocuments.ca/constitution/#s-76)  
+[77\. Speaker of Legislative Council](https://primarydocuments.ca/constitution/#s-77)  
+[78\. Quorum of Legislative Council](https://primarydocuments.ca/constitution/#s-78)  
+[79\. Voting in Legislative Council](https://primarydocuments.ca/constitution/#s-79)  
+[80\. Constitution of Legislative Assembly of Quebec](https://primarydocuments.ca/constitution/#s-80)  
+[81\. First Session of Legislatures](https://primarydocuments.ca/constitution/#s-81)  
+[82\. Summoning of Legislative Assemblies](https://primarydocuments.ca/constitution/#s-82)  
+[83\. Restriction on Election of Holders Offices](https://primarydocuments.ca/constitution/#s-83)  
+[84\. Continuance of Existing Election Laws](https://primarydocuments.ca/constitution/#s-84)  
+[85\. Duration of Legislative Assemblies](https://primarydocuments.ca/constitution/#s-85)  
+[86\. Yearly Session of Legislature](https://primarydocuments.ca/constitution/#s-86)  
+[87\. Speaker, Quorum, etc.](https://primarydocuments.ca/constitution/#s-87)  
+[88\. Constitutions of Legislatures of Nova Scotia and New Brunswick](https://primarydocuments.ca/constitution/#s-88)  
+[89\. First Elections](https://primarydocuments.ca/constitution/#s-89)  
+[90\. Application to Legislatures of Provisions Respecting Money Votes, etc.](https://primarydocuments.ca/constitution/#s-90)
+
+**[VI. DISTRIBUTION OF LEGISLATIVE POWERS (91-95)](https://primarydocuments.ca/constitution/#part-vi)**  
+[91\. Legislative Authority of Parliament of Canada](https://primarydocuments.ca/constitution/#s-91)  
+[1-29. Amendment as to Legislative Authority of Parliament of Canada](https://primarydocuments.ca/constitution/#s-91-1-29)  
+[92\. Subjects of Exclusive Provincial Legislation](https://primarydocuments.ca/constitution/#s-92)  
+[92A.(1) Laws Respecting Non-Renewable Natural Resources, Forestry Resources and Electrical Energy](https://primarydocuments.ca/constitution/#s-92a1)  
+[(2) Export From Provinces of Resources](https://primarydocuments.ca/constitution/#s-92a2)  
+[(3) Authority of Parliament](https://primarydocuments.ca/constitution/#s-92a3)  
+[(4) Taxation of Resources](https://primarydocuments.ca/constitution/#s-92a4)  
+[(5) “Primary Production”](https://primarydocuments.ca/constitution/#s-92a5)  
+[(6) Existing Powers or Rights](https://primarydocuments.ca/constitution/#s-92a6)  
+[93\. Legislation Respecting Education](https://primarydocuments.ca/constitution/#s-93)  
+[94\. Legislation for Uniformity of Laws in Three Provinces](https://primarydocuments.ca/constitution/#s-94)  
+[94A. Legislation Respecting Old Age Pensions and Supplementary Benefits](https://primarydocuments.ca/constitution/#s-94a)  
+[95\. Concurrent Powers of Legislation Respecting Agriculture, etc.](https://primarydocuments.ca/constitution/#s-95)
+
+**[VII. JUDICATURE (96-101)](https://primarydocuments.ca/constitution/#part-vii)**  
+[96\. Appointment of Judges](https://primarydocuments.ca/constitution/#s-96)  
+[97\. Selections of Judges in Ontario, etc.](https://primarydocuments.ca/constitution/#s-97)  
+[98\. Selection of Judges in Quebec](https://primarydocuments.ca/constitution/#s-98)  
+[99\. Tenure of Office of Judges](https://primarydocuments.ca/constitution/#s-99)  
+[100\. Salaries, etc., of Judges](https://primarydocuments.ca/constitution/#s-100)  
+[101\. General Court of Appeal, etc.](https://primarydocuments.ca/constitution/#s-101)
+
+**[VIII. REVENUES; DEBTS; ASSETS; TAXATION (102-126)](https://primarydocuments.ca/constitution/#part-viii)**  
+[102\. Creation of Consolidated Revenue Fund](https://primarydocuments.ca/constitution/#s-102)  
+[103\. Expenses of Collection, etc.](https://primarydocuments.ca/constitution/#s-103)  
+[104\. Interest of Provincial Public Debts](https://primarydocuments.ca/constitution/#s-104)  
+[105\. Salary of Governor General](https://primarydocuments.ca/constitution/#s-105)  
+[106\. Appropriation from Time to Time](https://primarydocuments.ca/constitution/#s-106)  
+[107\. Transfer of Stocks, etc.](https://primarydocuments.ca/constitution/#s-107)  
+[108\. Transfer of Property in Schedule](https://primarydocuments.ca/constitution/#s-108)  
+[109\. Property in Lands, Mines, etc.](https://primarydocuments.ca/constitution/#s-109)  
+[110\. Assets Connected With Provincial Debts](https://primarydocuments.ca/constitution/#s-110)  
+[111\. Canada to be Liable for Provincial Debts](https://primarydocuments.ca/constitution/#s-111)  
+[112\. Debts of Ontario and Quebec](https://primarydocuments.ca/constitution/#s-112)  
+[113\. Assets of Ontario and Quebec](https://primarydocuments.ca/constitution/#s-113)  
+[114\. Debt of Nova Scotia](https://primarydocuments.ca/constitution/#s-114)  
+[115\. Debt of New Brunswick](https://primarydocuments.ca/constitution/#s-115)  
+[116\. Payment of Interest to Nova Scotia and New Brunswick](https://primarydocuments.ca/constitution/#s-116)  
+[117\. Provincial Public Property](https://primarydocuments.ca/constitution/#s-117)  
+[118\. Grants to Provinces](https://primarydocuments.ca/constitution/#s-118)  
+[119\. Further Grant to New Brunswick](https://primarydocuments.ca/constitution/#s-119)  
+[120\. Form of Payments](https://primarydocuments.ca/constitution/#s-120)  
+[121\. Canadian Manufactures, etc.](https://primarydocuments.ca/constitution/#s-121)  
+[122\. Continuance of Customs and Excise Laws](https://primarydocuments.ca/constitution/#s-122/)  
+[123\. Exportation and Importation as Between Two Provinces](https://primarydocuments.ca/constitution/#s-123/)  
+[124\. Lumber Dues in New Brunswick](https://primarydocuments.ca/constitution/#s-124/)  
+[125\. Exemption of Public Lands, etc.](https://primarydocuments.ca/constitution/#s-125/)  
+[126\. Provincial Consolidated Revenue Fund](https://primarydocuments.ca/constitution/#s-126)
+
+**[IX. MISCELLANEOUS PROVISIONS (127-144)](https://primarydocuments.ca/constitution/#part-ix)**  
+[127\. As to Legislative Councillors of Provinces Becoming Senators](https://primarydocuments.ca/constitution/#s-127)  
+[128\. Oaths of Allegiance, etc.](https://primarydocuments.ca/constitution/#s-128)  
+[129\. Continuance of Existing Laws, Courts, Officers, etc.](https://primarydocuments.ca/constitution/#s-129)  
+[130\. Transfer of Officers to Canada](https://primarydocuments.ca/constitution/#s-130)  
+[131\. Appointment of New Officers](https://primarydocuments.ca/constitution/#s-131)  
+[132\. Treaty Obligations](https://primarydocuments.ca/constitution/#s-132)  
+[133\. Use of English and French Languages](https://primarydocuments.ca/constitution/#s-133)  
+[134\. Appointment of Executive Officers for Ontario and Quebec](https://primarydocuments.ca/constitution/#s-134)  
+[135\. Powers, Duties, etc. of Executive Officers](https://primarydocuments.ca/constitution/#s-135)  
+[136\. Great Seals](https://primarydocuments.ca/constitution/#s-136)  
+[137\. Construction of Temporary Acts](https://primarydocuments.ca/constitution/#s-137)  
+[138\. As to Errors in names](https://primarydocuments.ca/constitution/#s-138)  
+[139\. As to Issue of Proclamations Before Union, to Commence After Union](https://primarydocuments.ca/constitution/#s-139)  
+[140\. As to Issue of Proclamations After Union](https://primarydocuments.ca/constitution/#s-140)  
+[141\. Penitentiary](https://primarydocuments.ca/constitution/#s-141)  
+[142\. Arbitration Respecting Debts, etc.](https://primarydocuments.ca/constitution/#s-142)  
+[143\. Division of Records](https://primarydocuments.ca/constitution/#s-143)  
+[144\. Constitution of Townships in Quebec](https://primarydocuments.ca/constitution/#s-144)
+
+**[X. INTERCOLONIAL RAILWAY (145)](https://primarydocuments.ca/constitution/#part-x)**  
+[145\. Duty of Government and Parliament of Canada to Make Railway Herein Described](https://primarydocuments.ca/constitution/#s-145)
+
+**[XI. ADMISSION OF OTHER COLONIES (146)](https://primarydocuments.ca/constitution/#part-xi)**  
+[146\. Power to Admit Newfoundland, etc., into the Union](https://primarydocuments.ca/constitution/#s-146)  
+[147\. As to Representation of Newfoundland and Prince Edward Island in Senate](https://primarydocuments.ca/constitution/#s-147)
+
+**[SCHEDULES](https://primarydocuments.ca/constitution/#schedules)**
+
+---
+
+\[Note: The present short title was substituted for the  
+original short title (in italics) by the *[Constitution Act, 1982](https://primarydocuments.ca/constitution-act-1982/)* (No. 44 *infra*).\]
+
+30 & 31 Victoria, c. 3 (U.K.)
+
+An Act for the Union of Canada, Nova Scotia,  
+and New Brunswick, and the Government  
+thereof; and for Purposes connected therewith
+
+*\[29th March 1867\]*
+
+---
+
+Whereas the Provinces of Canada, Nova Scotia, and New Brunswick have expressed their Desire to be federally united into One Dominion under the Crown of the United Kingdom of Great Britain and Ireland, with a Constitution similar in Principle to that of the United Kingdom:
+
+And whereas such a Union would conduce to the Welfare of the Provinces and promote the Interests of the British Empire:
+
+And whereas on the Establishment of the Union by Authority of Parliament it is expedient, not only that the Constitution of the Legislative Authority in the Dominion be provided for, but also that the Nature of the Executive Government therein be declared:
+
+And whereas it is expedient that Provision be made for the eventual Admission into the Union of other Parts of British North America:
+
+*Be it therefore enacted and declared by the Queen’s most Excellent Majesty, by and with the Advice and Consent of the Lords Spiritual and Temporal, and Commons, in this present Parliament assembled, and by the Authority of the same, as follows:*
+
+\[Note: The enacting clause was repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to the preamble.” less=”Hide”\]Documents related to the preamble:\[posts-by-tag tags = “Preamble” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### I. PRELIMINARY
+
+1\. This Act may be cited as *The British North America Act, 1867*.
+
+1\. This Act may be cited as the *Constitution Act, 1867*. \[Note: Section 1 (in italics) was repealed and the new section substituted by the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 1.” less=”Hide”\]Documents related to section 1:\[posts-by-tag tags = “Section 1” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*2\. The Provisions of this Act referring to Her Majesty the Queen extend also to the Heirs and Successors of Her Majesty, Kings and Queens of the United Kingdom of Great Britain and Ireland.*
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/1893/06/09/statute-law-revision-act-1893/)* (No. 17 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 2.” less=”Hide”\]Documents related to section 2:\[posts-by-tag tags = “Section 2” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### II. UNION
+
+\[show\_more more=”Click here for documents related to Part II.” less=”Hide”\]Documents related to Part II:\[posts-by-tag tags = “Part II” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+3\. It shall be lawful for the Queen, by and with the Advice of Her Majesty’s Most Honourable Privy Council, to declare by Proclamation that, on and after a Day therein appointed, not being more than Six Months after the passing of this Act, the Provinces of Canada, Nova Scotia, and New Brunswick shall form and be One Dominion under the Name of Canada; and on and after that Day those Three Provinces shall form and be One Dominion under that Name accordingly.
+
+\[Note: The first day of July, 1867 was fixed by [proclamation dated May 22, 1867](https://primarydocuments.ca/a-proclamation-for-uniting-the-provinces-of-canada-nova-scotia-and-new-brunswick-into-one-dominion-under-the-name-of-canada/).\]  
+\[show\_more more=”Click here for documents related to section 3.” less=”Hide”\]Documents related to section 3:\[posts-by-tag tags = “Section 3” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*4\. The subsequent Provisions of this Act shall, unless it is otherwise expressed or implied, commence and have effect on and after the Union, that is to say, on and after the Day appointed for the Union taking effect in the Queen’s Proclamation; and in the same Provisions*, unless it is otherwise expressed or implied, the Name Canada shall be taken to mean Canada as constituted under this Act.
+
+\[Note: The words in italics were repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 4.” less=”Hide”\]Documents related to section 4:\[posts-by-tag tags = “Section 4” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+5\. Canada shall be divided into Four Provinces, named Ontario, Quebec, Nova Scotia, and New Brunswick.  
+\[show\_more more=”Click here for documents related to section 5.” less=”Hide”\]Documents related to section 5:\[posts-by-tag tags = “Section 5” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+6\. The Parts of the Province of Canada (as it exists at the passing of this Act) which formerly constituted respectively the Provinces of Upper Canada and Lower Canada shall be deemed to be severed, and shall form Two separate Provinces. The Part which formerly constituted the Province of Upper Canada shall constitute the Province of Ontario; and the Part which formerly constituted the Province of Lower Canada shall constitute the Province of Quebec.  
+\[show\_more more=”Click here for documents related to section 6.” less=”Hide”\]Documents related to section 6:\[posts-by-tag tags = “Section 6” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+7\. The Provinces of Nova Scotia and New Brunswick shall have the same Limits as at the passing of this Act.  
+\[show\_more more=”Click here for documents related to section 7.” less=”Hide”\]Documents related to section 7:\[posts-by-tag tags = “Section 7” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+8\. In the general Census of the Population of Canada which is hereby required to be taken in the Year One thousand eight hundred and seventy-one, and in every Tenth Year thereafter, the respective Populations of the Four Provinces shall be distinguished.  
+\[show\_more more=”Click here for documents related to section 8.” less=”Hide”\]Documents related to section 8:\[posts-by-tag tags = “Section 8” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### III. EXECUTIVE POWER
+
+\[show\_more more=”Click here for documents related to Part III.” less=”Hide”\]Documents related to Part III:\[posts-by-tag tags = “Part III” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+9\. The Executive Government and Authority of and over Canada is hereby declared to continue and be vested in the Queen.  
+\[show\_more more=”Click here for documents related to section 9.” less=”Hide”\]Documents related to section 9:\[posts-by-tag tags = “Section 9” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+10\. The Provisions of this Act referring to the Governor General extend and apply to the Governor General for the Time being of Canada, or other the Chief Executive Officer or Administrator for the Time being carrying on the Government of Canada on behalf and in the Name of the Queen, by whatever Title he is designated.  
+\[show\_more more=”Click here for documents related to section 10.” less=”Hide”\]Documents related to section 10:\[posts-by-tag tags = “Section 10” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+11\. There shall be a Council to aid and advise in the Government of Canada, to be styled the Queen’s Privy Council for Canada; and the Persons who are to be Members of that Council shall be from Time to Time chosen and summoned by the Governor General and sworn in as Privy Councillors, and Members thereof may be from Time to Time removed by the Governor General.  
+\[show\_more more=”Click here for documents related to section 11.” less=”Hide”\]Documents related to section 11:\[posts-by-tag tags = “Section 11” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+12\. All Powers, Authorities, and Functions which under any Act of the Parliament of Great Britain, or of the Parliament of the United Kingdom of Great Britain and Ireland, or of the Legislature of Upper Canada, Lower Canada, Canada, Nova Scotia, or New Brunswick, are at the Union vested in or exerciseable by the respective Governors or Lieutenant Governors of those Provinces, with the Advice, or with the Advice and Consent, of the respective Executive Councils thereof, or in conjunction with those Councils, or with any Number of Members thereof, or by those Governors or Lieutenant Governors individually, shall, as far as the same continue in existence and capable of being exercised after the Union in relation to the Government of Canada, be vested in and exerciseable by the Governor General, with the Advice or with the Advice and Consent of or in conjunction with the Queen’s Privy Council for Canada, or any Members thereof, or by the Governor General individually, as the Case requires, subject nevertheless (except with respect to such as exist under Acts of the Parliament of Great Britain or of the Parliament of the United Kingdom of Great Britain and Ireland) to be abolished or altered by the Parliament of Canada.
+
+\[Note: See the note to section 129.\]  
+\[show\_more more=”Click here for documents related to section 12.” less=”Hide”\]Documents related to section 12:\[posts-by-tag tags = “Section 12” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+13\. The Provisions of this Act referring to the Governor General in Council shall be construed as referring to the Governor General acting by and with the Advice of the Queen’s Privy Council for Canada.  
+\[show\_more more=”Click here for documents related to section 13.” less=”Hide”\]Documents related to section 13:\[posts-by-tag tags = “Section 13” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+14\. It shall be lawful for the Queen, if Her Majesty thinks fit, to authorize the Governor General from Time to Time to appoint any Person or any Persons jointly or severally to be his Deputy or Deputies within any Part or Parts of Canada, and in that Capacity to exercise during the Pleasure of the Governor General such of the Powers, Authorities, and Functions of the Governor General as the Governor General deems it necessary or expedient to assign to him or them, subject to any Limitations or Directions expressed or given by the Queen; but the Appointment of such a Deputy or Deputies shall not affect the Exercise by the Governor General himself of any Power, Authority, or Function.  
+\[show\_more more=”Click here for documents related to section 14.” less=”Hide”\]Documents related to section 14:\[posts-by-tag tags = “Section 14” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+15\. The Command-in-Chief of the Land and Naval Militia, and of all Naval and Military Forces, of and in Canada, is hereby declared to continue and be vested in the Queen.  
+\[show\_more more=”Click here for documents related to section 15.” less=”Hide”\]Documents related to section 15:\[posts-by-tag tags = “Section 15” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+16\. Until the Queen otherwise directs, the Seat of Government of Canada shall be Ottawa.  
+\[show\_more more=”Click here for documents related to section 16.” less=”Hide”\]Documents related to section 16:\[posts-by-tag tags = “Section 16” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### IV. LEGISLATIVE POWER
+
+\[show\_more more=”Click here for documents related to Part IV.” less=”Hide”\]Documents related to Part IV:\[posts-by-tag tags = “Part IV” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+17\. There shall be One Parliament for Canada, consisting of the Queen, an Upper House styled the Senate, and the House of Commons.
+
+\[show\_more more=”Click here for documents related to section 17.” less=”Hide”\]Documents related to section 17:\[posts-by-tag tags = “Section 17” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*18\. The Privileges, Immunities, and Powers to be held, enjoyed, and exercised by the Senate and by the House of Commons and by the Members thereof respectively shall be such as are from Time to Time defined by Act of the Parliament of Canada, but so that the same shall never exceed those at the passing of this Act held, enjoyed, and exercised by the Commons House of Parliament of the United Kingdom of Great Britain and Ireland and by the Members thereof.*
+
+18\. The privileges, immunities, and powers to be held, enjoyed, and exercised by the Senate and by the House of Commons, and by the members thereof respectively, shall be such as are from time to time defined by Act of the Parliament of Canada, but so that any Act of the Parliament of Canada defining such privileges, immunities, and powers shall not confer any privileges, immunities, or powers exceeding those at the passing of such Act held, enjoyed, and exercised by the Commons House of Parliament of the United Kingdom of Great Britain and Ireland, and by the members thereof.
+
+\[Note: Section 18 (in italics) was repealed and the new section substituted by the *[Parliament of Canada Act, 1875](https://primarydocuments.ca/parliament-of-canada-act-1875/)* (No. 13 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 18.” less=”Hide”\]Documents related to section 18:\[posts-by-tag tags = “Section 18” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+19\. The Parliament of Canada shall be called together not later than Six Months after the Union.
+
+\[Note: The first session of the first Parliament began on November 6, 1867.\]
+
+\[show\_more more=”Click here for documents related to section 19.” less=”Hide”\]Documents related to section 19:\[posts-by-tag tags = “Section 19” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*20\. There shall be a Session of the Parliament of Canada once at least in every Year, so that Twelve Months shall not intervene between the last Sitting of the Parliament in one Session and its first sitting in the next Session.*
+
+\[Note: Repealed by the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*). See also section 5 of that Act, which provides that there shall be a sitting of Parliament at least once every twelve months.\]
+
+\[show\_more more=”Click here for documents related to section 20.” less=”Hide”\]Documents related to section 20:\[posts-by-tag tags = “Section 20” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*The Senate*
+
+21\. The Senate shall, subject to the Provisions of this Act, consist of *Seventy-two Members*, who shall be styled Senators.
+
+\[Note: The Senate now consists of 104 Members, as amended by the *[Constitution Act, 1915](https://primarydocuments.ca/constitution-act-1915/)* (No. 23 *infra*) and modified by the [*Newfoundland Act*](https://primarydocuments.ca/newfoundland-act/) (No. 32 *infra*) and as again amended by the [*Constitution Act* (No. 2), 1975](https://primarydocuments.ca/constitution-act-1975-no-2/) (No. 42 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 21.” less=”Hide”\]Documents related to section 21:\[posts-by-tag tags = “Section 21” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+22\. In relation to the Constitution of the Senate Canada shall be deemed to consist of *Three* Divisions:  
+1\. Ontario;  
+2\. Quebec;  
+*3\. The Maritime Provinces, Nova Scotia and New Brunswick*;  
+which *Three* Divisions shall (subject to the Provisions of this Act) be equally represented in the Senate as follows: Ontario by Twenty-four Senators; Quebec by Twenty-four Senators; and the Maritime Provinces by Twenty-four Senators, *Twelve* thereof representing Nova Scotia, and *Twelve* thereof representing New Brunswick.
+
+In the Case of Quebec each of the Twenty-four Senators representing that Province shall be appointed for One of the Twenty-four Electoral Divisions of Lower Canada specified in Schedule A. to Chapter One of the Consolidated Statutes of Canada.
+
+\[Note: Prince Edward Island, on admission into the Union in 1873, became part of the third division with a representation in the Senate of four members, the representation of Nova Scotia and New Brunswick being reduced from twelve to ten members each. See Section 147.
+
+A fourth division represented in the Senate by twenty-four senators and comprising the Western Provinces of Manitoba, British Columbia, Alberta and Saskatchewan, each represented by six senators, was added by the *[Constitution Act, 1915](https://primarydocuments.ca/constitution-act-1915/)* (No. 23 *infra*).
+
+Newfoundland is represented in the Senate by six members. See the *[Constitution Act, 1915](https://primarydocuments.ca/constitution-act-1915/)* (No. 23 *infra*) and the [*Newfoundland Act*](https://primarydocuments.ca/newfoundland-act/) (No. 32 *infra*).
+
+The Yukon Territory and the Northwest Territories are represented in the Senate by one member each. See the [*Constitution Act* (No. 2), 1975](https://primarydocuments.ca/constitution-act-1975-no-2/) (No. 42 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 22.” less=”Hide”\]Documents related to section 22:\[posts-by-tag tags = “Section 22” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+23\. The Qualifications of a Senator shall be as follows:  
+\[show\_more more=”Click here for documents related to section 23.” less=”Hide”\]Documents related to section 23:\[posts-by-tag tags = “Section 23” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+1\. He shall be of the full age of Thirty Years:  
+\[show\_more more=”Click here for documents related to section 23(1).” less=”Hide”\]Documents related to section 23(1):\[posts-by-tag tags = “Section 23(1)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+2\. He shall be either a natural-born Subject of the Queen, or a Subject of the Queen naturalized by an Act of the Parliament of Great Britain, or of the Parliament of the United Kingdom of Great Britain and Ireland, or of the Legislature of One of the Provinces of Upper Canada, Lower Canada, Canada, Nova Scotia, or New Brunswick, before the Union, or of the Parliament of Canada after the Union:  
+\[show\_more more=”Click here for documents related to section 23(2).” less=”Hide”\]Documents related to section 23(2):\[posts-by-tag tags = “Section 23(2)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+3\. He shall be legally or equitably seised as of Freehold for his own Use and Benefit of Lands or Tenements held in Free and Common Socage, or seised or possessed for his own Use and Benefit of Lands or Tenements held in Franc-alleu or in Roture, within the Province for which he is appointed, of the Value of Four thousand Dollars, over and above all Rents, Dues, Debts, Charges, Mortgages, and Incumbrances due or payable out of or charged on or affecting the same:  
+\[show\_more more=”Click here for documents related to section 23(3).” less=”Hide”\]Documents related to section 23(3):\[posts-by-tag tags = “Section 23(3)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+4\. His Real and Personal Property shall be together worth Four thousand Dollars over and above his Debts and Liabilities:  
+\[show\_more more=”Click here for documents related to section 23(4).” less=”Hide”\]Documents related to section 23(4):\[posts-by-tag tags = “Section 23(4)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+5\. He shall be resident in the Province for which he is appointed:  
+\[show\_more more=”Click here for documents related to section 23(5).” less=”Hide”\]Documents related to section 23(5):\[posts-by-tag tags = “Section 23(5)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+6\. In the Case of Quebec he shall have his Real Property Qualification in the Electoral Division for which he is appointed, or shall be resident in that Division.  
+\[show\_more more=”Click here for documents related to section 23(6).” less=”Hide”\]Documents related to section 23(6):\[posts-by-tag tags = “Section 23(6)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+\[Note: For the purposes of the [*Constitution Act* (No. 2), 1975](https://primarydocuments.ca/constitution-act-1975-no-2/) (No. 42 *infra*), the term “Province” in section 23 has the same meaning as is assigned to the term “province” by section 35 of the *[Interpretation Act](http://laws-lois.justice.gc.ca/eng/acts/I-21/index.html)* (Canada).\]
+
+24\. The Governor General shall from Time to Time, in the Queen’s Name, by Instrument under the Great Seal of Canada, summon qualified Persons to the Senate; and, subject to the Provisions of this Act, every Person so summoned shall become and be a Member of the Senate and a Senator.  
+\[show\_more more=”Click here for documents related to section 24.” less=”Hide”\]Documents related to section 24:\[posts-by-tag tags = “Section 24” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+25\. *Such Persons shall be first summoned to the Senate as the Queen by Warrant under Her Majesty’s Royal Sign Manual thinks fit to approve, and their Names shall be inserted in the Queen’s Proclamation of Union.*
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 25.” less=”Hide”\]Documents related to section 25:\[posts-by-tag tags = “Section 25” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+26\. If at any Time on the Recommendation of the Governor General the Queen thinks fit to direct that *Three or Six* Members be added to the Senate, the Governor General may by Summons to *Three or Six* qualified Persons (as the Case may be), representing equally the Three Divisions of Canada, add to the Senate accordingly.
+
+\[Note: The number of members who may be added to the Senate was increased from three or six to four or eight, representing equally the four divisions of Canada. See the *[Constitution Act, 1915](https://primarydocuments.ca/constitution-act-1915/)* (No. 23 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 26.” less=”Hide”\]Documents related to section 26:\[posts-by-tag tags = “Section 26” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+27\. In case of such Addition being at any Time made, the Governor General shall not summon any Person to the Senate, except on a further like Direction by the Queen on the like Recommendation, until each of the Three Divisions of Canada is represented by Twenty-four Senators and no more.
+
+\[Note: Superseded by the *[Constitution Act, 1915](https://primarydocuments.ca/constitution-act-1915/)* , paragraph 1(1)(iv), (No. 23 *infra*). This paragraph reads as follows:
+
+“In case of such addition being at any time made the Governor General of Canada shall not summon any person to the Senate except upon a further like direction by His Majesty the King on the like recommendation to represent one of the four Divisions until such Division is represented by twenty-four senators and no more:”\]  
+\[show\_more more=”Click here for documents related to section 27.” less=”Hide”\]Documents related to section 27:\[posts-by-tag tags = “Section 27” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+28\. The Number of Senators shall not at any Time exceed *Seventy-eight*.
+
+\[Note: The maximum number of senators is now 112, as amended by the *[Constitution Act, 1915](https://primarydocuments.ca/constitution-act-1915/)* (No. 23 *infra*) and the [*Constitution Act* (No. 2), 1975](https://primarydocuments.ca/constitution-act-1975-no-2/) (No. 42 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 28.” less=”Hide”\]Documents related to section 28:\[posts-by-tag tags = “Section 28” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+29\. *A Senator shall, subject to the Provisions of this Act, hold his Place in the Senate for Life.*  
+\[show\_more more=”Click here for documents related to section 29.” less=”Hide”\]Documents related to section 29:\[posts-by-tag tags = “Section 29” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+29\. (1) Subject to subsection (2), a Senator shall, subject to the provisions of this Act, hold his place in the Senate for life.  
+\[show\_more more=”Click here for documents related to section 29 (1).” less=”Hide”\]Documents related to section 29 (1):\[posts-by-tag tags = “Section 29 (1)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+(2) A Senator who is summoned to the Senate after the coming into force of this subsection shall, subject to this Act, hold his place in the Senate until he attains the age of seventy-five years.
+
+\[Note: Section 29 (in italics) was repealed and the new section substituted by the [*Constitution Act, 1965*](https://primarydocuments.ca/constitution-act-1965/) (No. 39 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 29 (2).” less=”Hide”\]Documents related to section 29 (2):\[posts-by-tag tags = “Section 29 (2)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+30\. A Senator may by Writing under his Hand addressed to the Governor General resign his Place in the Senate, and thereupon the same shall be vacant.  
+\[show\_more more=”Click here for documents related to section 30.” less=”Hide”\]Documents related to section 30:\[posts-by-tag tags = “Section 30” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+31\. The Place of a Senator shall become vacant in any of the following Cases:  
+\[show\_more more=”Click here for documents related to section 31.” less=”Hide”\]Documents related to section 31:\[posts-by-tag tags = “Section 31” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+1\. If for Two consecutive Sessions of the Parliament he fails to give his Attendance in the Senate:  
+\[show\_more more=”Click here for documents related to section 31(1).” less=”Hide”\]Documents related to section 31(1):\[posts-by-tag tags = “Section 31(1)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+2\. If he takes an Oath or makes a Declaration or Acknowledgment of Allegiance, Obedience, or Adherence to a Foreign Power, or does an Act whereby he becomes a Subject or Citizen, or entitled to the Rights or Privileges of a Subject or Citizen, of a Foreign Power:  
+\[show\_more more=”Click here for documents related to section 31(2).” less=”Hide”\]Documents related to section 31(2):\[posts-by-tag tags = “Section 31(2)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+3\. If he is adjudged Bankrupt or Insolvent, or applies for the Benefit of any Law relating to Insolvent Debtors, or becomes a public Defaulter:  
+\[show\_more more=”Click here for documents related to section 31(3).” less=”Hide”\]Documents related to section 31(3):\[posts-by-tag tags = “Section 31(3)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+4\. If he is attainted of Treason or convicted of Felony or of any infamous Crime:  
+\[show\_more more=”Click here for documents related to section 31(4).” less=”Hide”\]Documents related to section 31(4):\[posts-by-tag tags = “Section 31(4)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+5\. If he ceases to be qualified in respect of Property or of Residence; provided, that a Senator shall not be deemed to have ceased to be qualified in respect of Residence by reason only of his residing at the Seat of the Government of Canada while holding an Office under that Government requiring his Presence there.  
+\[show\_more more=”Click here for documents related to section 31(5).” less=”Hide”\]Documents related to section 31(5):\[posts-by-tag tags = “Section 31(5)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+32\. When a Vacancy happens in the Senate by Resignation, Death, or otherwise, the Governor General shall by Summons to a fit and qualified Person fill the Vacancy.  
+\[show\_more more=”Click here for documents related to section 32.” less=”Hide”\]Documents related to section 32:\[posts-by-tag tags = “Section 32” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+33\. If any Question arises respecting the Qualification of a Senator or a Vacancy in the Senate the same shall be heard and determined by the Senate.  
+\[show\_more more=”Click here for documents related to section 33.” less=”Hide”\]Documents related to section 33:\[posts-by-tag tags = “Section 33” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+34\. The Governor General may from Time to Time, by Instrument under the Great Seal of Canada, appoint a Senator to be Speaker of the Senate, and may remove him and appoint another in his Stead.
+
+\[Note: See also the *[Canadian Speaker (Appointment of Deputy) Act, 1895](https://primarydocuments.ca/canadian-speaker-appointment-of-deputy-act-1895-session-2/)* (No. 18 *infra*) and the provisions concerning the Speaker of the Senate in the *[Parliament of Canada Act](http://laws-lois.justice.gc.ca/eng/acts/p-1/index.html)* (Canada).\]  
+\[show\_more more=”Click here for documents related to section 34.” less=”Hide”\]Documents related to section 34:\[posts-by-tag tags = “Section 34” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+35\. Until the Parliament of Canada otherwise provides, the Presence of at least Fifteen Senators, including the Speaker, shall be necessary to constitute a Meeting of the Senate for the Exercise of its Powers.  
+\[show\_more more=”Click here for documents related to section 35.” less=”Hide”\]Documents related to section 35:\[posts-by-tag tags = “Section 35” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+36\. Questions arising in the Senate shall be decided by a Majority of Voices, and the Speaker shall in all Cases have a Vote, and when the Voices are equal the Decision shall be deemed to be in the Negative.  
+\[show\_more more=”Click here for documents related to section 36.” less=”Hide”\]Documents related to section 36:\[posts-by-tag tags = “Section 36” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*The House of Commons*
+
+37\. The House of Commons shall, subject to the Provisions of this Act, consist of *One hundred and eighty-one* Members, of whom *Eighty-two* shall be elected for Ontario, *Sixty-five* for Quebec, *Nineteen* for Nova Scotia, and *Fifteen* for New Brunswick.
+
+\[Note: On October 31, 1987, the House of Commons consisted of 282 members: 95 for Ontario, 75 for Quebec, II for Nova Scotia, 10 for New Brunswick, 14 for Manitoba, 28 for British Columbia, 4 for Prince Edward Island, 21 for Alberta, 14 for Saskatchewan, 7 for Newfoundland, 1 for the Yukon Territory and 2 for the Northwest Territories.
+
+These figures result from the application of section 51 as re-enacted by the [*Constitution Act, 1974*](https://primarydocuments.ca/constitution-act-1974/) (No. 40 *infra*) and amended by the *[Constitution Act (No. 1), 1975](https://primarydocuments.ca/constitution-act-1975-no-1/)* (No. 41 *infra*), and of the *[Electoral Boundaries Readjustment Act](http://laws-lois.justice.gc.ca/eng/acts/E-3/page-1.html)* (Canada).\]  
+\[show\_more more=”Click here for documents related to section 37.” less=”Hide”\]Documents related to section 37:\[posts-by-tag tags = “Section 37” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+38\. The Governor General shall from Time to Time, in the Queen’s Name, by Instrument under the Great Seal of Canada, summon and call together the House of Commons.  
+\[show\_more more=”Click here for documents related to section 38.” less=”Hide”\]Documents related to section 38:\[posts-by-tag tags = “Section 38” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+39\. A Senator shall not be capable of being elected or of sitting or voting as a Member of the House of Commons.  
+\[show\_more more=”Click here for documents related to section 39.” less=”Hide”\]Documents related to section 39:\[posts-by-tag tags = “Section 39” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+40\. Until the Parliament of Canada otherwise provides, Ontario, Quebec, Nova Scotia, and New Brunswick shall, for the Purposes of the Election of Members to serve in the House of Commons, be divided into Electoral Districts as follows:
+
+1\. ONTARIO
+
+Ontario shall be divided into the Counties, Ridings of Counties, Cities, Parts of Cities, and Towns enumerated in the First Schedule to this Act, each whereof shall be an Electoral District, each such District as numbered in that Schedule being entitled to return One Member.
+
+2\. QUEBEC
+
+Quebec shall be divided into Sixty-five Electoral Districts, composed of the Sixty-five Electoral Divisions into which Lower Canada is at the passing of this Act divided under Chapter Two of the Consolidated Statutes of Canada, Chapter Seventy-five of the Consolidated Statutes for Lower Canada, and the Act of the Province of Canada of the Twenty-third Year of the Queen, Chapter One, or any other Act amending the same in force at the Union, so that each such Electoral Division shall be for the Purposes of this Act an Electoral District entitled to return One Member.
+
+3\. NOVA SCOTIA
+
+Each of the Eighteen Counties of Nova Scotia shall be an Electoral District. The County of Halifax shall be entitled to return Two Members, and each of the other Counties One Member.
+
+4\. NEW BRUNSWICK
+
+Each of the Fourteen Counties into which New Brunswick is divided, including the City and County of St. John, shall be an Electoral District. The City of St. John shall also be a separate Electoral District. Each of those Fifteen Electoral Districts shall be entitled to return One Member.
+
+\[Note: The federal electoral districts of the 10 provinces and the Northwest Territories are now set out in the schedule to Proclamations issued from time to time pursuant to the *[Electoral Boundaries Readjustment Act](http://laws-lois.justice.gc.ca/eng/acts/E-3/page-1.html)* (Canada), as amended for particular districts by other Acts of Parliament.
+
+The electoral district of the Yukon Territory is set out in section 30 of the *[Electoral Boundaries Readjustment Act](http://laws-lois.justice.gc.ca/eng/acts/E-3/page-1.html)* (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 40.” less=”Hide”\]Documents related to section 40:\[posts-by-tag tags = “Section 40” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+41\. Until the Parliament of Canada otherwise provides, all Laws in force in the several Provinces at the Union relative to the following Matters or any of them, namely,—the Qualifications and Disqualifications of Persons to be elected or to sit or vote as Members of the House of Assembly or Legislative Assembly in the several Provinces, the Voters at Elections of such Members, the Oaths to be taken by Voters, the Returning Officers, their Powers and Duties, the Proceedings at Elections, the Periods during which Elections may be continued, the Trial of controverted Elections, and Proceedings incident thereto, the vacating of Seats of Members, and the Execution of new Writs in case of Seats vacated otherwise than by Dissolution,—shall respectively apply to Elections of Members to serve in the House of Commons for the same several Provinces.
+
+Provided that, until the Parliament of Canada otherwise provides, at any Election for a Member of the House of Commons for the District of Algoma, in addition to Persons qualified by the Law of the Province of Canada to vote, every Male British Subject, aged Twenty-one Years or upwards, being a Householder, shall have a Vote.
+
+\[Note: The principal provisions concerning elections are now found in the *[Parliament of Canada Act](http://laws-lois.justice.gc.ca/eng/acts/p-1/index.html)*, [*Canada Elections Act*](http://laws-lois.justice.gc.ca/eng/acts/E-2.01/) and *Dominion Controverted Elections Act* (all three enacted by Canada). The right to vote and hold office is provided for in section 3 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 41.” less=”Hide”\]Documents related to section 41:\[posts-by-tag tags = “Section 41” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+42\. *For the First Election of Members to serve in the House of Commons the Governor General shall cause Writs to be issued by such Person, in such Form, and addressed to such Returning Officers as he thinks fit.*
+
+*The Person issuing Writs under this Section shall have the like Powers as are possessed at the Union by the Officers charged with the issuing of Writs for the Election of Members to serve in the respective House of Assembly or Legislative Assembly of the Province of Canada, Nova Scotia, or New Brunswick; and the Returning Officers to whom Writs are directed under this Section shall have the like Powers as are possessed at the Union by the Officers charged with the returning of Writs for the Election of Members to serve in the same respective House of Assembly or Legislative Assembly.*
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 42.” less=”Hide”\]Documents related to section 42:\[posts-by-tag tags = “Section 42” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+43.*In case a Vacancy in the Representation in the House of Commons of any Electoral District happens before the Meeting of the Parliament, or after the Meeting of the Parliament before Provision is made by the Parliament in this Behalf, the Provisions of the last foregoing Section of this Act shall extend and apply to the issuing and returning of a Writ in respect of such Vacant District.*
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 43.” less=”Hide”\]Documents related to section 43:\[posts-by-tag tags = “Section 43” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+44\. The House of Commons on its first assembling after a General Election shall proceed with all practicable Speed to elect One of its Members to be Speaker.
+
+\[show\_more more=”Click here for documents related to section 44.” less=”Hide”\]Documents related to section 44:\[posts-by-tag tags = “Section 44” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+45\. In case of a Vacancy happening in the Office of Speaker by Death, Resignation, or otherwise, the House of Commons shall with all practicable Speed proceed to elect another of its Members to be Speaker.
+
+\[show\_more more=”Click here for documents related to section 45.” less=”Hide”\]Documents related to section 45:\[posts-by-tag tags = “Section 45” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+46\. The Speaker shall preside at all Meetings of the House of Commons.
+
+\[show\_more more=”Click here for documents related to section 46.” less=”Hide”\]Documents related to section 46:\[posts-by-tag tags = “Section 46” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+47\. Until the Parliament of Canada otherwise provides, in case of the Absence for any Reason of the Speaker from the Chair of the House of Commons for a Period of Forty-eight consecutive Hours, the House may elect another of its Members to act as Speaker, and the Member so elected shall during the Continuance of such Absence of the Speaker have and execute all the Powers, Privileges, and Duties of Speaker.
+
+\[Note: See also the provisions concerning the Speaker of the House of Commons in the *[Parliament of Canada Act](http://laws-lois.justice.gc.ca/eng/acts/p-1/index.html)* (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 47.” less=”Hide”\]Documents related to section 47:\[posts-by-tag tags = “Section 47” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+48\. The Presence of at least Twenty Members of the House of Commons shall be necessary to constitute a Meeting of the House for the Exercise of its Powers, and for that Purpose the Speaker shall be reckoned as a Member.
+
+\[show\_more more=”Click here for documents related to section 48.” less=”Hide”\]Documents related to section 48:\[posts-by-tag tags = “Section 48” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+49\. Questions arising in the House of Commons shall be decided by a Majority of Voices other than that of the Speaker, and when the Voices are equal, but not otherwise, the Speaker shall have a Vote.
+
+\[show\_more more=”Click here for documents related to section 49.” less=”Hide”\]Documents related to section 49:\[posts-by-tag tags = “Section 49” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+50\. Every House of Commons shall continue for Five Years from the Day of the Return of the Writs for choosing the House (subject to be sooner dissolved by the Governor General), and nolonger
+
+\[Note: See for an extension of this term the *[British North America Act, 1916](https://primarydocuments.ca/british-north-america-act-1916/)* (No. 24 *infra*). See also section 4 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 50.” less=”Hide”\]Documents related to section 50:\[posts-by-tag tags = “Section 50” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*51\. On the Completion of the Census in the Year One thousand eight hundred and seventy-one, and of each subsequent decennial Census, the Representation of the Four Provinces shall be readjusted by such Authority, in such Manner, and from such Time, as the Parliament of Canada from Time to Time provides, subject and according to the following Rules:*
+
+*1\. Quebec shall have the fixed Number of Sixty- five Members:  
+2\. There shall be assigned to each of the other Provinces such a Number of Members as will bear the same Proportion to the Number of its Population (ascertained at such Census) as the Number Sixty-five bears to the Number of the Population of Quebec (so ascertained):  
+3\. In the Computation of the Number of Members for a Province a fractional Part not exceeding One Half of the whole Number requisite for entitling the Province to a Member shall be disregarded; but a fractional Part exceeding One Half of that Number shall be equivalent to the whole Number:  
+4\. On any such Re-adjustment the Number of Members for a Province shall not be reduced unless the Proportion which the Number of the Population of the Province bore to the Number of the aggregate Population of Canada at the then last preceding Re-adjustment of the Number of Members for the Province is ascertained at the then latest Census to be diminished by One Twentieth Part or upwards:  
+5\. Such Re-adjustment shall not take effect until the Termination of the then existing Parliament.*
+
+\[show\_more more=”Click here for documents related to section 51.” less=”Hide”\]Documents related to section 51:\[posts-by-tag tags = “Section 51” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+51\. (1) The number of members of the House of Commons and the representation of the provinces therein shall, on the coming into force of this subsection and thereafter on the completion of each decennial census, be readjusted by such authority, in such manner, and from such time as the Parliament of Canada from time to time provides, subject and according to the following rules:
+
+\[show\_more more=”Click here for documents related to section 51 (1).” less=”Hide”\]Documents related to section 51 (1):\[posts-by-tag tags = “Section 51 (1)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+1\. There shall be assigned to each of the provinces a number of members equal to the number obtained by dividing the total population of the provinces by two hundred and seventy-nine and by dividing the population of each province by the quotient so obtained, counting any remainder in excess of 0.50 as one after the said process of division.
+
+2\. If the total number of members that would be assigned to a province by the application of rule 1 is less than the total number assigned to that province on the date of coming into force of this subsection, there shall be added to the number of members so assigned such number of members as will result in the province having the same number of members as were assigned on that date.
+
+\[show\_more more=”Click here for documents related to section 51 (1) 1-2.” less=”Hide”\]Documents related to section 51 (1) 1-2:\[posts-by-tag tags = “Section 51 (1) 1-2” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+(2) The Yukon Territory as bounded and described in the schedule to chapter Y-2 of the Revised Statutes of Canada, 1970, shall be entitled to one member, and the Northwest Territories as bounded and described in section 2 of chapter N-22 of the Revised Statutes of Canada, 1970, shall be entitled to two members.
+
+\[Note: The original section 51 (in italics) was repealed and a new section 51 substituted by the *[British North America Act, 1946](https://primarydocuments.ca/british-northamerica-act-1946/)* (No. 30 *infra*).
+
+The section enacted in 1946 was repealed and a new section 51 substituted by the [*British North America Act, 1952*](https://primarydocuments.ca/british-north-america-act-1952/) (No. 36 *infra*).
+
+Subsection (1) of the section 51 enacted in 1952 was repealed and a new subsection 51(1) substituted by the [*Constitution Act, 1974*](https://primarydocuments.ca/constitution-act-1974/) (No. 40 *infra*). The subsection 51(1) enacted in 1974 was repealed and the present subsection 51(1) substituted by the [*Constitution Act, 1985 (Representation)*](https://primarydocuments.ca/constitution-act-representation-1985/) (No. 47 *infra*).
+
+Subsection (2) of the section 51 enacted in 1952 was repealed and the present subsection 51(2) substituted by the *[Constitution Act (No. 1), 1975](https://primarydocuments.ca/constitution-act-1975-no-1/) (No. 41 *infra*).*
+
+The words from “of the census” to “seventy-one and” and the word “subsequent” of the original section had previously been repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 51 (2).” less=”Hide”\]Documents related to section 51 (2):\[posts-by-tag tags = “Section 51 (2)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+51A. Notwithstanding anything in this Act a province shall always be entitled to a number of members in the House of Commons not less than the number of senators representing such province.
+
+\[Note: Added by the *[Constitution Act, 1915](https://primarydocuments.ca/constitution-act-1915/)* (No. 23 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 51A.” less=”Hide”\]Documents related to section 51A:\[posts-by-tag tags = “Section 51A” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+52\. The Number of Members of the House of Commons may be from Time to Time increased by the Parliament of Canada, provided the proportionate Representation of the Provinces prescribed by this Act is not thereby disturbed.
+
+\[show\_more more=”Click here for documents related to section 52.” less=”Hide”\]Documents related to section 52:\[posts-by-tag tags = “Section 52” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Money Votes; Royal Assent*
+
+53\. Bills for appropriating any Part of the Public Revenue, or for imposing any Tax or Impost, shall originate in the House of Commons.
+
+\[show\_more more=”Click here for documents related to section 53.” less=”Hide”\]Documents related to section 53:\[posts-by-tag tags = “Section 53” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+54\. It shall not be lawful for the House of Commons to adopt or pass any Vote, Resolution, Address, or Bill for the Appropriation of any Part of the Public Revenue, or of any Tax or Impost, to any Purpose that has not been first recommended to that House by Message of the Governor General in the Session in which such Vote, Resolution, Address, or Bill is proposed.
+
+\[show\_more more=”Click here for documents related to section 54.” less=”Hide”\]Documents related to section 54:\[posts-by-tag tags = “Section 54” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+55\. Where a Bill passed by the Houses of the Parliament is presented to the Governor General for the Queen’s Assent, he shall declare, according to his Discretion, but subject to the Provisions of this Act and to Her Majesty’s Instructions, either that he assents thereto in the Queen’s Name, or that he withholds the Queen’s Assent, or that he reserves the Bill for the Signification of the Queen’s Pleasure.
+
+\[show\_more more=”Click here for documents related to section 55.” less=”Hide”\]Documents related to section 55:\[posts-by-tag tags = “Section 55” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+56\. Where the Governor General assents to a Bill in the Queen’s Name, he shall by the first convenient Opportunity send an authentic Copy of the Act to One of Her Majesty’s Principal Secretaries of State, and if the Queen in Council within Two Years after Receipt thereof by the Secretary of State thinks fit to disallow the Act, such Disallowance (with a Certificate of the Secretary of State of the Day on which the Act was received by him) being signified by the Governor General, by Speech or Message to each of the Houses of the Parliament or by Proclamation, shall annul the Act from and after the Day of such Signification.
+
+\[show\_more more=”Click here for documents related to section 56.” less=”Hide”\]Documents related to section 56:\[posts-by-tag tags = “Section 56” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+57\. A Bill reserved for the Signification of the Queen’s Pleasure shall not have any Force unless and until, within Two Years from the Day on which it was presented to the Governor General for the Queen’s Assent, the Governor General signifies, by Speech or Message to each of the Houses of the Parliament or by Proclamation, that it has received the Assent of the Queen in Council.
+
+An Entry of every such Speech, Message, or Proclamation shall be made in the Journal of each House, and a Duplicate thereof duly attested shall be delivered to the proper Officer to be kept among the Records of Canada.
+
+\[show\_more more=”Click here for documents related to section 57.” less=”Hide”\]Documents related to section 57:\[posts-by-tag tags = “Section 57” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### V. PROVINCIAL CONSTITUTIONS
+
+\[show\_more more=”Click here for documents related to Part V.” less=”Hide”\]Documents related to Part V:\[posts-by-tag tags = “Part V” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Executive Power*
+
+58\. For each Province there shall be an Officer, styled the Lieutenant Governor, appointed by the Governor General in Council by Instrument under the Great Seal of Canada.
+
+\[show\_more more=”Click here for documents related to section 58.” less=”Hide”\]Documents related to section 58:\[posts-by-tag tags = “Section 58” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+59\. A Lieutenant Governor shall hold Office during the Pleasure of the Governor General; but any Lieutenant Governor appointed after the Commencement of the First Session of the Parliament of Canada shall not be removeable within Five Years from his Appointment, except for Cause assigned, which shall be communicated to him in Writing within One Month after the Order for his Removal is made, and shall be communicated by Message to the Senate and to the House of Commons within One Week thereafter if the Parliament is then sitting, and if not then within One Week after the Commencement of the next Session of the Parliament.
+
+\[show\_more more=”Click here for documents related to section 59.” less=”Hide”\]Documents related to section 59:\[posts-by-tag tags = “Section 59” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+60\. The Salaries of the Lieutenant Governors shall be fixed and provided by the Parliament of Canada.
+
+\[Note: See the [*Salaries Act*](http://laws-lois.justice.gc.ca/eng/acts/S-3/) (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 60.” less=”Hide”\]Documents related to section 60:\[posts-by-tag tags = “Section 60” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+61\. Every Lieutenant Governor shall, before assuming the Duties of his Office, make and subscribe before the Governor General or some Person authorized by him Oaths of Allegiance and Office similar to those taken by the Governor General.
+
+\[show\_more more=”Click here for documents related to section 61.” less=”Hide”\]Documents related to section 61:\[posts-by-tag tags = “Section 61” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+62\. The Provisions of this Act referring to the Lieutenant Governor extend and apply to the Lieutenant Governor for the Time being of each Province, or other the Chief Executive Officer or Administrator for the Time being carrying on the Government of the Province, by whatever Title he is designated.
+
+\[show\_more more=”Click here for documents related to section 62.” less=”Hide”\]Documents related to section 62:\[posts-by-tag tags = “Section 62” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+63\. The Executive Council of Ontario and of Quebec shall be composed of such Persons as the Lieutenant Governor from Time to Time thinks fit, and in the first instance of the following Officers, namely,—the Attorney General, the Secretary and Registrar of the Province, the Treasurer of the Province, the Commissioner of Crown Lands, and the Commissioner of Agriculture and Public Works, within Quebec the Speaker of the Legislative Council and the Solicitor General.
+
+\[Note: See the [*Executive Council Act* (Ontario)](https://www.ontario.ca/laws/statute/90e25) and the [*Executive Power Act* (Quebec)](http://legisquebec.gouv.qc.ca/en/ShowDoc/cs/E-18).\]
+
+\[show\_more more=”Click here for documents related to section 63.” less=”Hide”\]Documents related to section 63:\[posts-by-tag tags = “Section 63” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+64\. The Constitution of the Executive Authority in each of the Provinces of Nova Scotia and New Brunswick shall, subject to the Provisions of this Act, continue as it exists at the Union until altered under the Authority of this Act.
+
+\[Note: The instruments admitting British Columbia, Prince Edward Island and Newfoundland contain similar provisions and the [*Manitoba Act, 1870*](https://primarydocuments.ca/manitoba-act-1870/), [*Alberta Act*](https://primarydocuments.ca/alberta-act/) and *[Saskatchewan Act](https://primarydocuments.ca/saskatchewan-act/)* establish the executive authorities in the three provinces concerned. See the note to section 146.\]
+
+\[show\_more more=”Click here for documents related to section 64.” less=”Hide”\]Documents related to section 64:\[posts-by-tag tags = “Section 64” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+65\. All Powers, Authorities, and Functions which under any Act of the Parliament of Great Britain, or of the Parliament of the United Kingdom of Great Britain and Ireland, or of the Legislature of Upper Canada, Lower Canada, or Canada, were or are before or at the Union vested in or exerciseable by the respective Governors or Lieutenant Governors of those Provinces, with the Advice or with the Advice and Consent of the respective Executive Councils thereof, or in conjunction with those Councils, or with any Number of Members thereof, or by those Governors or Lieutenant Governors individually, shall, as far as the same are capable of being exercised after the Union in relation to the Government of Ontario and Quebec respectively, be vested in and shall or may be exercised by the Lieutenant Governor of Ontario and Quebec respectively, with the Advice or with the Advice and Consent of or in conjunction with the respective Executive Councils, or any Members thereof, or by the Lieutenant Governor individually, as the Case requires, subject nevertheless (except with respect to such as exist under Acts of the Parliament of Great Britain, or of the Parliament of the United Kingdom of Great Britain and Ireland,) to be abolished or altered by the respective Legislatures of Ontario and Quebec.
+
+\[Note: See the note to section 129.\]
+
+\[show\_more more=”Click here for documents related to section 65.” less=”Hide”\]Documents related to section 65:\[posts-by-tag tags = “Section 65” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+66\. The Provisions of this Act referring to the Lieutenant Governor in Council shall be construed as referring to the Lieutenant Governor of the Province acting by and with the Advice of the Executive Council thereof.
+
+\[show\_more more=”Click here for documents related to section 66.” less=”Hide”\]Documents related to section 66:\[posts-by-tag tags = “Section 66” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+67\. The Governor General in Council may from Time to Time appoint an Administrator to execute the Office and Functions of Lieutenant Governor during his Absence, Illness, or other Inability.
+
+\[show\_more more=”Click here for documents related to section 67.” less=”Hide”\]Documents related to section 67:\[posts-by-tag tags = “Section 67” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+68\. Unless and until the Executive Government of any Province otherwise directs with respect to that Province, the Seats of Government of the Provinces shall be as follows, namely,—of Ontario, the City of Toronto; of Quebec, the City of Quebec; of Nova Scotia, the City of Halifax; and of New Brunswick, the City of Fredericton.
+
+\[show\_more more=”Click here for documents related to section 68.” less=”Hide”\]Documents related to section 68:\[posts-by-tag tags = “Section 68” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Legislative Power*
+
+1\. ONTARIO
+
+69\. There shall be a Legislature for Ontario consisting of the Lieutenant Governor and of One House, styled the Legislative Assembly of Ontario.
+
+\[show\_more more=”Click here for documents related to section 69.” less=”Hide”\]Documents related to section 69:\[posts-by-tag tags = “Section 69” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+70\. The Legislative Assembly of Ontario shall be composed of Eighty-two Members, to be elected to represent the Eighty-two Electoral Districts set forth in the First Schedule to this Act.
+
+\[Note: See the [*Representation Act* (Ontario)](https://www.ontario.ca/laws/statute/15r31).\]
+
+\[show\_more more=”Click here for documents related to section 70.” less=”Hide”\]Documents related to section 70:\[posts-by-tag tags = “Section 70” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+2\. QUEBEC
+
+71\. There shall be a Legislature for Quebec consisting of the Lieutenant Governor and of Two Houses, styled the Legislative Council of Quebec and the Legislative Assembly of Quebec.
+
+\[Note: The Legislative Council was abolished by the Act respecting the Legislative Council of Quebec, Statutes of Quebec, 1968, c. 9. Sections 72 to 79 following are therefore spent.\]
+
+\[show\_more more=”Click here for documents related to section 71.” less=”Hide”\]Documents related to section 71:\[posts-by-tag tags = “Section 71” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+72\. The Legislative Council of Quebec shall be composed of Twenty-four Members, to be appointed by the Lieutenant Governor, in the Queen’s Name, by Instrument under the Great Seal of Quebec, one being appointed to represent each of the Twenty-four Electoral Divisions of Lower Canada in this Act referred to, and each holding Office for the Term of his Life, unless the Legislature of Quebec otherwise provides under the Provisions of this Act.
+
+\[show\_more more=”Click here for documents related to section 72.” less=”Hide”\]Documents related to section 72:\[posts-by-tag tags = “Section 72” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+73\. The Qualifications of the Legislative Councillors of Quebec shall be the same as those of the Senators for Quebec.
+
+\[show\_more more=”Click here for documents related to section 73.” less=”Hide”\]Documents related to section 73:\[posts-by-tag tags = “Section 73” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+74\. The Place of a Legislative Councillor of Quebec shall become vacant in the Cases, mutatis mutandis, in which the Place of Senator becomes vacant.
+
+\[show\_more more=”Click here for documents related to section 74.” less=”Hide”\]Documents related to section 74:\[posts-by-tag tags = “Section 74” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+75\. When a Vacancy happens in the Legislative Council of Quebec by Resignation, Death, or otherwise, the Lieutenant Governor, in the Queen’s Name, by Instrument under the Great Seal of Quebec, shall appoint a fit and qualified Person to fill the Vacancy.
+
+\[show\_more more=”Click here for documents related to section 75.” less=”Hide”\]Documents related to section 75:\[posts-by-tag tags = “Section 75” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+76\. If any Question arises respecting the Qualification of a Legislative Councillor of Quebec, or a Vacancy in the Legislative Council of Quebec, the same shall be heard and determined by the Legislative Council.
+
+\[show\_more more=”Click here for documents related to section 76.” less=”Hide”\]Documents related to section 76:\[posts-by-tag tags = “Section 76” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+77\. The Lieutenant Governor may from Time to Time, by Instrument under the Great Seal of Quebec, appoint a Member of the Legislative Council of Quebec to be Speaker thereof, and may remove him and appoint another in his Stead.
+
+\[show\_more more=”Click here for documents related to section 77.” less=”Hide”\]Documents related to section 77:\[posts-by-tag tags = “Section 77” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+78\. Until the Legislature of Quebec otherwise provides, the Presence of at least Ten Members of the Legislative Council, including the Speaker, shall be necessary to constitute a Meeting for the Exercise of its Powers.
+
+\[show\_more more=”Click here for documents related to section 78.” less=”Hide”\]Documents related to section 78:\[posts-by-tag tags = “Section 78” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+79\. Questions arising in the Legislative Council of Quebec shall be decided by a Majority of Voices, and the Speaker shall in all Cases have a Vote, and when the Voices are equal the Decision shall be deemed to be in the Negative.
+
+\[show\_more more=”Click here for documents related to section 79.” less=”Hide”\]Documents related to section 79:\[posts-by-tag tags = “Section 79” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+80\. The Legislative Assembly of Quebec shall be composed of Sixty-five Members, to be elected to represent the Sixty-five Electoral Divisions or Districts of Lower Canada in this Act referred to, subject to Alteration thereof by the Legislature of Quebec: Provided that it shall not be lawful to present to the Lieutenant Governor of Quebec for Assent any Bill for altering the Limits of any of the Electoral Divisions or Districts mentioned in the Second Schedule to this Act, unless the Second and Third Readings of such Bill have been passed in the Legislative Assembly with the Concurrence of the Majority of the Members representing all those Electoral Divisions or Districts, and the Assent shall not be given to such Bill unless an Address has been presented by the Legislative Assembly to the Lieutenant Governor stating that it has been so passed.
+
+\[Note: Declared to be of no effect by the Act respecting electoral districts, Statutes of Quebec, 1970, c. 7.\]
+
+\[show\_more more=”Click here for documents related to section 80.” less=”Hide”\]Documents related to section 80:\[posts-by-tag tags = “Section 80” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+3\. ONTARIO AND QUEBEC
+
+81\. The Legislatures of Ontario and Quebec respectively shall be called together not later than Six Months after the Union.
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 81.” less=”Hide”\]Documents related to section 81:\[posts-by-tag tags = “Section 81” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+82\. The Lieutenant Governor of Ontario and of Quebec shall from Time to Time, in the Queen’s Name, by Instrument under the Great Seal of the Province, summon and call together the Legislative Assembly of the Province.
+
+\[show\_more more=”Click here for documents related to section 82.” less=”Hide”\]Documents related to section 82:\[posts-by-tag tags = “Section 82” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+83\. Until the Legislature of Ontario or of Quebec otherwise provides, a Person accepting or holding in Ontario or in Quebec any Office, Commission, or Employment, permanent or temporary, at the Nomination of the Lieutenant Governor, to which an annual Salary, or any Fee, Allowance, Emolument, or Profit of any Kind or Amount whatever from the Province is attached, shall not be eligible as a Member of the Legislative Assembly of the respective Province, nor shall he sit or vote as such; but nothing in this Section shall make ineligible any Person being a Member of the Executive Council of the respective Province, or holding any of the following Offices, that is to say, the Offices of Attorney General, Secretary and Registrar of the Province, Treasurer of the Province, Commissioner of Crown Lands, and Commissioner of Agriculture and Public Works, and in Quebec Solicitor General, or shall disqualify him to sit or vote in the House for which he is elected, provided he is elected while holding such Office.
+
+\[Note: See also the [*Legislative Assembly Act* (Ontario)](https://www.ontario.ca/laws/statute/90l10) and the [*National Assembly Act* (Quebec)](http://legisquebec.gouv.qc.ca/en/showdoc/cs/A-23.1).\]
+
+\[show\_more more=”Click here for documents related to section 83.” less=”Hide”\]Documents related to section 83:\[posts-by-tag tags = “Section 83” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+84\. Until the Legislatures of Ontario and Quebec respectively otherwise provide, all Laws which at the Union are in force in those Provinces respectively, relative to the following Matters, or any of them, namely,—the Qualifications and Disqualifications of Persons to be elected or to sit or vote as Members of the Assembly of Canada, the Qualifications or Disqualifications of Voters, the Oaths to be taken by Voters, the Returning Officers, their Powers and Duties, the Proceedings at Elections, the Periods during which such Elections may be continued, and the Trial of controverted Elections and the Proceedings incident thereto, the vacating of the Seats of Members and the issuing and execution of new Writs in case of Seats vacated otherwise than by Dissolution,—shall respectively apply to Elections of Members to serve in the respective Legislative Assemblies of Ontario and Quebec.
+
+Provided that, until the Legislature of Ontario otherwise provides, at any Election for a Member of the Legislative Assembly of Ontario for the District of Algoma, in addition to Persons qualified by the Law of the Province of Canada to vote, every Male British Subject, aged Twenty-one Years or upwards, being a Householder, shall have a Vote.
+
+\[Note: See also the *[Election Act](https://www.ontario.ca/laws/statute/90e06)* and *[Legislative Assembly Act (Ontario)](https://www.ontario.ca/laws/statute/90l10)* and the *[Elections Act](http://legisquebec.gouv.qc.ca/en/ShowDoc/cs/E-3.3)* and [*National Assembly Act (Quebec)*](http://legisquebec.gouv.qc.ca/en/showdoc/cs/A-23.1).\]
+
+\[show\_more more=”Click here for documents related to section 84.” less=”Hide”\]Documents related to section 84:\[posts-by-tag tags = “Section 84” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+85\. Every Legislative Assembly of Ontario and every Legislative Assembly of Quebec shall continue for Four Years from the Day of the Return of the Writs for choosing the same (subject nevertheless to either the Legislative Assembly of Ontario or the Legislative Assembly of Quebec being sooner dissolved by the Lieutenant Governor of the Province), and nolongen
+
+\[Note: Now five years in both provinces: see the [*Legislative Assembly Act* (Ontario)](https://www.ontario.ca/laws/statute/90l10) and the [*National Assembly Act* (Quebec)](http://legisquebec.gouv.qc.ca/en/showdoc/cs/A-23.1). See also section 4 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 85.” less=”Hide”\]Documents related to section 85:\[posts-by-tag tags = “Section 85” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+86\. There shall be a Session of the Legislature of Ontario and of that of Quebec once at least in every Year, so that Twelve Months shall not intervene between the last Sitting of the Legislature in each Province in one Session and its first Sitting in the next Session.
+
+\[Note: See section 5 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 86.” less=”Hide”\]Documents related to section 86:\[posts-by-tag tags = “Section 86” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+87\. The following Provisions of this Act respecting the House of Commons of Canada shall extend and apply to the Legislative Assemblies of Ontario and Quebec, that is to say,—the Provisions relating to the Election of a Speaker originally and on Vacancies, the Duties of the Speaker, the Absence of the Speaker, the Quorum, and the Mode of voting, as if those Provisions were here re-enacted and made applicable in Terms to each such Legislative Assembly.
+
+\[show\_more more=”Click here for documents related to section 87.” less=”Hide”\]Documents related to section 87:\[posts-by-tag tags = “Section 87” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+4\. NOVA SCOTIA AND NEW BRUNSWICK
+
+88\. The Constitution of the Legislature of each of the Provinces of Nova Scotia and New Brunswick shall, subject to the Provisions of this Act, continue as it exists at the Union until altered under the Authority of this Act; and the House of Assembly of New Brunswick existing at the passing of this Act shall, unless sooner dissolved, continue for the Period for which it was elected.
+
+\[Note: The words in italics were repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*). The note to section 64 also applies to the Legislatures of the provinces mentioned therein. See also sections 3 to 5 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*) and sub-item 2(2) of the Schedule to that Act.\]
+
+\[show\_more more=”Click here for documents related to section 88.” less=”Hide”\]Documents related to section 88:\[posts-by-tag tags = “Section 88” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+5\. ONTARIO, QUEBEC, AND NOVA SCOTIA
+
+89\. Each of the Lieutenant Governors of Ontario, Quebec and Nova Scotia shall cause Writs to be issued for the First Election of Members of the Legislative Assembly thereof in such Form and by such Person as he thinks fit, and at such Time and addressed to such Returning Officer as the Governor General directs, and so that the First Election of Member of Assembly for any Electoral District or any Subdivision thereof shall be held at the same Time and at the same Places as the Election for a Member to serve in the House of Commons of Canada for that Electoral District.
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 89.” less=”Hide”\]Documents related to section 89:\[posts-by-tag tags = “Section 89” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+6\. THE FOUR PROVINCES
+
+90\. The following Provisions of this Act respecting the Parliament of Canada, namely, —the Provisions relating to Appropriation and Tax Bills, the Recommendation of Money Votes, the Assent to Bills, the Disallowance of Acts, and the Signification of Pleasure on Bills reserved,—shall extend and apply to the Legislatures of the several Provinces as if those Provisions were here re-enacted and made applicable in Terms to the respective Provinces and the Legislatures thereof, with the Substitution of the Lieutenant Governor of the Province for the Governor General, of the Governor General for the Queen and for a Secretary of State, of One Year for Two Years, and of the Province for Canada.
+
+\[show\_more more=”Click here for documents related to section 90.” less=”Hide”\]Documents related to section 90:\[posts-by-tag tags = “Section 90” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### VI. DISTRIBUTION OF LEGISLATIVE POWERS
+
+\[show\_more more=”Click here for documents related to Part VI.” less=”Hide”\]Documents related to Part VI:\[posts-by-tag tags = “Part VI” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Powers of the Parliament*
+
+91\. It shall be lawful for the Queen, by and with the Advice and Consent of the Senate and House of Commons, to make Laws for the Peace, Order, and good Government of Canada, in relation to all Matters not coming within the Classes of Subjects by this Act assigned exclusively to the Legislatures of the Provinces; and for greater Certainty, but not So as to restrict the Generality of the foregoing Terms of this Section, it is hereby declared that (notwithstanding anything in this Act) the exclusive Legislative Authority of the Parliament of Canada extends to all Matters coming Within the Classes of Subjects next herein-after enumerated; that is to say,—
+
+\[show\_more more=”Click here for documents related to section 91.” less=”Hide”\]Documents related to section 91:\[posts-by-tag tags = “Section 91” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+1\. The amendment from time to time of the Constitution of Canada, except as regards matters coming within the classes of subjects by this Act assigned exclusively to the Legislatures of the provinces, or as regards rights or privileges by this or any other Constitutional Act granted or secured to the Legislature or the Government of a province, or to any class of persons with respect to schools or as regards the use of the English or the French language or as regards the requirements that there shall be a session of the Parliament of Canada at least once each year, and that no House of Commons shall continue for more than five years from the day of the return of the Writs for choosing the House: Provided, however, that a House of Commons may in time of real or apprehended war, invasion or insurrection be continued by the Parliament of Canada if such continuation is not opposed by the votes of more than one-third of the members of such House.
+
+\[Note: Class 1 was added by the [British North America Act (No. 2), 1949](https://primarydocuments.ca/british-north-america-no-2-act-1949/) (No. 33 *infra*) and repealed by the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 91(1).” less=”Hide”\]Documents related to section 91(1):\[posts-by-tag tags = “Section 91(1)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+1A. The Public Debt and Property. \[Note: Re-numbered 1A by the [*British North America Act (No. 2), 1949*](https://primarydocuments.ca/british-north-america-no-2-act-1949/) (No. 33 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 91(1A).” less=”Hide”\]Documents related to section 91(1A):\[posts-by-tag tags = “Section 91(1A)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+2\. The Regulation of Trade and Commerce.  
+\[show\_more more=”Click here for documents related to section 91(2).” less=”Hide”\]Documents related to section 91(2):\[posts-by-tag tags = “Section 91(2)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+2A. Unemployment insurance. \[Note: Added by the [*Constitution Act, 1940*](https://primarydocuments.ca/constitution-act-1940/) (No. 28 *infra*).\]  
+\[show\_more more=”Click here for documents related to section 91(2A).” less=”Hide”\]Documents related to section 91(2A):\[posts-by-tag tags = “Section 91(2A)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+3\. The raising of Money by any Mode or System of Taxation.  
+\[show\_more more=”Click here for documents related to section 91(3).” less=”Hide”\]Documents related to section 91(3):\[posts-by-tag tags = “Section 91(3)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+4\. The borrowing of Money on the Public Credit.  
+\[show\_more more=”Click here for documents related to section 91(4).” less=”Hide”\]Documents related to section 91(4):\[posts-by-tag tags = “Section 91(4)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+5\. Postal Service.  
+\[show\_more more=”Click here for documents related to section 91(5).” less=”Hide”\]Documents related to section 91(5):\[posts-by-tag tags = “Section 91(5)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+6\. The Census and Statistics.  
+\[show\_more more=”Click here for documents related to section 91(6).” less=”Hide”\]Documents related to section 91(6):\[posts-by-tag tags = “Section 91(6)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+7\. Militia, Military and Naval Service, and Defence.  
+\[show\_more more=”Click here for documents related to section 91(7).” less=”Hide”\]Documents related to section 91(7):\[posts-by-tag tags = “Section 91(7)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+8\. The fixing of and providing for the Salaries and Allowances of Civil and other Officers of the Government of Canada.  
+\[show\_more more=”Click here for documents related to section 91(8).” less=”Hide”\]Documents related to section 91(8):\[posts-by-tag tags = “Section 91(8)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+9\. Beacons, Buoys, Lighthouses, and Sable Island.  
+\[show\_more more=”Click here for documents related to section 91(9).” less=”Hide”\]Documents related to section 91(9):\[posts-by-tag tags = “Section 91(9)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+10\. Navigation and Shipping.  
+\[show\_more more=”Click here for documents related to section 91(10).” less=”Hide”\]Documents related to section 91(10):\[posts-by-tag tags = “Section 91(10)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+11\. Quarantine and the Establishment and Maintenance of Marine Hospitals.  
+\[show\_more more=”Click here for documents related to section 91(11).” less=”Hide”\]Documents related to section 91(11):\[posts-by-tag tags = “Section 91(11)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+12\. Sea Coast and Inland Fisheries.  
+\[show\_more more=”Click here for documents related to section 91(12).” less=”Hide”\]Documents related to section 91(12):\[posts-by-tag tags = “Section 91(12)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+13\. Ferries between a Province and any British or Foreign Country or between Two Provinces.  
+\[show\_more more=”Click here for documents related to section 91(13).” less=”Hide”\]Documents related to section 91(13):\[posts-by-tag tags = “Section 91(13)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+14\. Currency and Coinage.  
+\[show\_more more=”Click here for documents related to section 91(14).” less=”Hide”\]Documents related to section 91(14):\[posts-by-tag tags = “Section 91(14)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+15\. Banking, Incorporation of Banks, and the Issue of Paper Money.  
+\[show\_more more=”Click here for documents related to section 91(15).” less=”Hide”\]Documents related to section 91(15):\[posts-by-tag tags = “Section 91(15)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+16\. Savings Banks.  
+\[show\_more more=”Click here for documents related to section 91(16).” less=”Hide”\]Documents related to section 91(16):\[posts-by-tag tags = “Section 91(16)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+17\. Weights and Measures.  
+\[show\_more more=”Click here for documents related to section 91(17).” less=”Hide”\]Documents related to section 91(17):\[posts-by-tag tags = “Section 91(17)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+18\. Bills of Exchange and Promissory Notes.  
+\[show\_more more=”Click here for documents related to section 91(18).” less=”Hide”\]Documents related to section 91(18):\[posts-by-tag tags = “Section 91(18)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+19\. Interest.  
+\[show\_more more=”Click here for documents related to section 91(19).” less=”Hide”\]Documents related to section 91(19):\[posts-by-tag tags = “Section 91(19)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+20\. Legal Tender.  
+\[show\_more more=”Click here for documents related to section 91(20).” less=”Hide”\]Documents related to section 91(20):\[posts-by-tag tags = “Section 91(20)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+21\. Bankruptcy and Insolvency.  
+\[show\_more more=”Click here for documents related to section 91(21).” less=”Hide”\]Documents related to section 91(21):\[posts-by-tag tags = “Section 91(21)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+22\. Patents of Invention and Discovery.  
+\[show\_more more=”Click here for documents related to section 91(22).” less=”Hide”\]Documents related to section 91(22):\[posts-by-tag tags = “Section 91(22)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+23\. Copyrights.  
+\[show\_more more=”Click here for documents related to section 91(23).” less=”Hide”\]Documents related to section 91(23):\[posts-by-tag tags = “Section 91(23)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+24\. Indians, and Lands reserved for the Indians.  
+\[show\_more more=”Click here for documents related to section 91(24).” less=”Hide”\]Documents related to section 91(24):\[posts-by-tag tags = “Section 91(24)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+25\. Naturalization and Aliens.  
+\[show\_more more=”Click here for documents related to section 91(25).” less=”Hide”\]Documents related to section 91(25):\[posts-by-tag tags = “Section 91(25)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+26\. Marriage and Divorce.  
+\[show\_more more=”Click here for documents related to section 91(26).” less=”Hide”\]Documents related to section 91(26):\[posts-by-tag tags = “Section 91(26)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+27\. The Criminal Law, except the Constitution of Courts of Criminal Jurisdiction, but including the Procedure in Criminal Matters.  
+\[show\_more more=”Click here for documents related to section 91(27).” less=”Hide”\]Documents related to section 91(27):\[posts-by-tag tags = “Section 91(27)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+28\. The Establishment, Maintenance, and Management of Penitentiaries.  
+\[show\_more more=”Click here for documents related to section 91(28).” less=”Hide”\]Documents related to section 91(28):\[posts-by-tag tags = “Section 91(28)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+29\. Such Classes of Subjects as are expressly excepted in the Enumeration of the Classes of Subjects by this Act assigned exclusively to the Legislatures of the Provinces.
+
+\[show\_more more=”Click here for documents related to section 91(29).” less=”Hide”\]Documents related to section 91(29):\[posts-by-tag tags = “Section 91(29)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+And any Matter coming within any of the Classes of Subjects enumerated in this Section shall not be deemed to come Within the Class of Matters of a local or private Nature comprised in the Enumeration of the Classes of Subjects by this Act assigned exclusively to the Legislatures of the Provinces.
+
+\[Note: Legislative authority has also been conferred by the [*Rupert’s Land Act, 1868*](https://primarydocuments.ca/ruperts-land-act-1868/) (No. 6 *infra*), *[Constitution Act, 1871](https://primarydocuments.ca/constitution-act-1871/)* (No. 11 *infra*), *[Constitution Act, 1886](https://primarydocuments.ca/constitution-act-1886/)* (No. 15 *infra*), [*Statute of Westminster, 1931*](https://primarydocuments.ca/statute-of-westminster-1931/) (No. 27 *infra*) and section 44 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*), and see also sections 38 and 41 to 43 of the latter Act.\]
+
+*Exclusive Powers of Provincial Legislatures*
+
+92\. In each Province the Legislature may exclusively make Laws in relation to Matters coming within the Classes of Subjects next herein-after enumerated; that is to say,—
+
+1\. The Amendment from Time to Time, notwithstanding anything in this Act, of the Constitution of the Province, except as regards the Office of Lieutenant Governor. \[Note: Class 1 was repealed by the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*). The subject is now provided for in section 45 of that Act, and see also sections 38 and 41 to 43 of the same Act.\]  
+\[show\_more more=”Click here for documents related to section 92(1).” less=”Hide”\]Documents related to section 92(1):\[posts-by-tag tags = “Section 92(1)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+2\. Direct Taxation within the Province in order to the raising of a Revenue for Provincial Purposes.  
+\[show\_more more=”Click here for documents related to section 92(2).” less=”Hide”\]Documents related to section 92(2):\[posts-by-tag tags = “Section 92(2)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+3\. The borrowing of Money on the sole Credit of the Province.  
+\[show\_more more=”Click here for documents related to section 92(3).” less=”Hide”\]Documents related to section 92(3):\[posts-by-tag tags = “Section 92(3)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+4\. The Establishment and Tenure of Provincial Offices and the Appointment and Payment of Provincial Officers.  
+\[show\_more more=”Click here for documents related to section 92(4).” less=”Hide”\]Documents related to section 92(4):\[posts-by-tag tags = “Section 92(4)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+5\. The Management and Sale of the Public Lands belonging to the Province and of the Timber and Wood thereon.  
+\[show\_more more=”Click here for documents related to section 92(5).” less=”Hide”\]Documents related to section 92(5):\[posts-by-tag tags = “Section 92(5)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+6\. The Establishment, Maintenance, and Management of Public and Reformatory Prisons in and for the Province.  
+\[show\_more more=”Click here for documents related to section 92(6).” less=”Hide”\]Documents related to section 92(6):\[posts-by-tag tags = “Section 92(6)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+7\. The Establishment, Maintenance, and Management of Hospitals, Asylums, Charities, and Eleemosynary Institutions in and for the Province, other than Marine Hospitals.  
+\[show\_more more=”Click here for documents related to section 92(7).” less=”Hide”\]Documents related to section 92(7):\[posts-by-tag tags = “Section 92(7)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+8\. Municipal Institutions in the Province.  
+\[show\_more more=”Click here for documents related to section 92(8).” less=”Hide”\]Documents related to section 92(8):\[posts-by-tag tags = “Section 92(8)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+9\. Shop, Saloon, Tavern, Auctioneer, and other Licences in order to the raising of a Revenue for Provincial, Local, or Municipal Purposes.  
+\[show\_more more=”Click here for documents related to section 92(9).” less=”Hide”\]Documents related to section 92(9):\[posts-by-tag tags = “Section 92(9)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+10\. Local Works and Undertakings other than such as are of the following Classes:—  
+a. Lines of Steam or other Ships, Railways, Canals, Telegraphs, and other Works and Undertakings connecting the Province with any other or others of the Provinces, or extending beyond the Limits of the Province:  
+b. Lines of Steam Ships between the Province and any British or Foreign Country:  
+c. Such Works as, although wholly situate within the Province, are before or after their Execution declared by the Parliament of Canada to be for the general Advantage of Canada or for the Advantage of Two or more of the Provinces.  
+\[show\_more more=”Click here for documents related to section 92(10).” less=”Hide”\]Documents related to section 92(10):\[posts-by-tag tags = “Section 92(10)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+11\. The Incorporation of Companies with Provincial Objects.  
+\[show\_more more=”Click here for documents related to section 92(11).” less=”Hide”\]Documents related to section 92(11):\[posts-by-tag tags = “Section 92(11)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+12\. The Solemnization of Marriage in the Province.  
+\[show\_more more=”Click here for documents related to section 92(12).” less=”Hide”\]Documents related to section 92(12):\[posts-by-tag tags = “Section 92(12)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+13\. Property and Civil Rights in the Province.  
+\[show\_more more=”Click here for documents related to section 92(13).” less=”Hide”\]Documents related to section 92(13):\[posts-by-tag tags = “Section 92(13)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+14\. The Administration of Justice in the Province, including the Constitution, Maintenance, and Organization of Provincial Courts, both of Civil and of Criminal Jurisdiction, and including Procedure in Civil Matters in those Courts.  
+\[show\_more more=”Click here for documents related to section 92(14).” less=”Hide”\]Documents related to section 92(14):\[posts-by-tag tags = “Section 92(14)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+15\. The Imposition of Punishment by Fine, Penalty, or Imprisonment for enforcing any Law of the Province made in relation to any Matter coming within any of the Classes of Subjects enumerated in this Section.  
+\[show\_more more=”Click here for documents related to section 92(15).” less=”Hide”\]Documents related to section 92(15:\[posts-by-tag tags = “Section 92(15)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+16\. Generally all Matters of a merely local or private Nature in the Province.
+
+\[show\_more more=”Click here for documents related to section 92(16).” less=”Hide”\]Documents related to section 92(16):\[posts-by-tag tags = “Section 92(16)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Non-Renewable Natural Resources, Forestry Resources and Electrical Energy*
+
+92A. (1) In each province, the legislature may exclusively make laws in relation to
+
+(a) exploration for non-renewable natural resources in the province;  
+(b) development, conservation and management of non-renewable natural resources and forestry resources in the province, including laws in relation to the rate of primary production therefrom; and  
+(c) development, conservation and management of sites and facilities in the province for the generation and production of electrical energy.
+
+\[show\_more more=”Click here for documents related to section 92A (1).” less=”Hide”\]Documents related to section 92A (1):\[posts-by-tag tags = “Section 92A (1)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+(2) In each province, the legislature may make laws in relation to the export from the province to another part of Canada of the primary production from non-renewable natural resources and forestry resources in the province and the production from facilities in the province for the generation of electrical energy, but such laws may not authorize or provide for discrimination in prices or in supplies exported to another part of Canada.
+
+\[show\_more more=”Click here for documents related to section 92A (2).” less=”Hide”\]Documents related to section 92A (2):\[posts-by-tag tags = “Section 92A (2)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+(3) Nothing in subsection (2) derogates from the authority of Parliament to enact laws in relation to the matters referred to in that subsection and, where such a law of Parliament and a law of a province conflict, the law of Parliament prevails to the extent of the conflict.
+
+\[show\_more more=”Click here for documents related to section 92A (3).” less=”Hide”\]Documents related to section 92A (3):\[posts-by-tag tags = “Section 92A (3)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+(4) In each province, the legislature may make laws in relation to the raising of money by any mode or system of taxation in respect of
+
+(a) non-renewable natural resources and forestry resources in the province and the primary production therefrom, and  
+(b) sites and facilities in the province for the generation of electrical energy and the production therefrom,
+
+whether or not such production is exported in whole or in part from the province, but such laws may not authorize or provide for taxation that differentiates between production exported to another part of Canada and production not exported from the province.
+
+\[show\_more more=”Click here for documents related to section 92A (4).” less=”Hide”\]Documents related to section 92A (4):\[posts-by-tag tags = “Section 92A (4)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+(5) The expression “primary production” has the meaning assigned by the Sixth Schedule.
+
+\[show\_more more=”Click here for documents related to section 92A (5).” less=”Hide”\]Documents related to section 92A (5):\[posts-by-tag tags = “Section 92A (5)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+(6) Nothing in subsections (1) to (5) derogates from any powers or rights that a legislature or government of a province had immediately before the coming into force of this section.
+
+\[Note: Added by section 50 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 92A (6).” less=”Hide”\]Documents related to section 92A (6):\[posts-by-tag tags = “Section 92A (6)” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Education*
+
+93\. In and for each Province the Legislature may exclusively make Laws in relation to Education, subject and according to the following Provisions:—
+
+(1) Nothing in any such Law shall prejudicially affect any Right or Privilege with respect to Denominational Schools which any Class of Persons have by Law in the Province at the Union:
+
+(2) All the Powers, Privileges, and Duties at the Union by Law conferred and imposed in Upper Canada on the Separate Schools and School Trustees of the Queen’s Roman Catholic Subjects shall be and the same are hereby extended to the Dissentient Schools of the Queen’s Protestant and Roman Catholic Subjects in Quebec:
+
+(3) Where in any Province a System of Separate or Dissentient Schools exists by Law at the Union or is thereafter established by the Legislature of the Province, an Appeal shall lie to the Governor General in Council from any Act or Decision of any Provincial Authority affecting any Right or Privilege of the Protestant or Roman Catholic Minority of the Queen’s Subjects in relation to Education:
+
+(4) In case any such Provincial Law as from Time to Time seems to the Governor General in Council requisite for the due Execution of the Provisions of this Section is not made, or in case any Decision of the Governor General in Council on any Appeal under this Section is not duly executed by the proper Provincial Authority in that Behalf, then and in every such Case, and as far only as the Circumstances of each Case require, the Parliament of Canada may make remedial Laws for the due Execution of the Provisions of this Section and of any Decision of the Governor General in Council under this Section.
+
+\[Note: Altered for Manitoba by section 22 of the [*Manitoba Act, 1870*](https://primarydocuments.ca/manitoba-act-1870/) (No. 8 *infra*) confirmed by the *[Constitution Act, 1871](https://primarydocuments.ca/constitution-act-1871/)* (No. 11 *infra*); for Alberta, by Section 17 of the [*Alberta Act*](https://primarydocuments.ca/alberta-act/) (No. 20 *infra*); for Saskatchewan, by section 17 of the *[Saskatchewan Act](https://primarydocuments.ca/saskatchewan-act/)* (No. 21 *infra*); and for Newfoundland, by Term 17 of the Terms of Union of Newfoundland with Canada, confirmed by the [*Newfoundland Act*](https://primarydocuments.ca/newfoundland-act/) (No. 32 *infra*). See also sections 23, 29 and 59 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 93.” less=”Hide”\]Documents related to section 93:\[posts-by-tag tags = “Section 93” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Uniformity of Laws in Ontario, Nova Scotia, and New Brunswick*
+
+94\. Notwithstanding anything in this Act, the Parliament of Canada may make Provision for the Uniformity of all or any of the Laws relative to Property and Civil Rights in Ontario, Nova Scotia, and New Brunswick, and of the Procedure of all or any of the Courts in those Three Provinces, and from and after the passing of any Act in that Behalf the Power of the Parliament of Canada to make Laws in relation to any Matter comprised in any such Act shall, notwithstanding anything in this Act, be unrestricted; but any Act of the Parliament of Canada making Provision for such Uniformity shall not have effect in any Province unless and until it is adopted and enacted as Law by the Legislature thereof.
+
+\[show\_more more=”Click here for documents related to section 94.” less=”Hide”\]Documents related to section 94:\[posts-by-tag tags = “Section 94” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+94A. The Parliament of Canada may make laws in relation to old age pensions and supplementary benefits, including survivors’ and disability benefits irrespective of age, but no such law shall affect the operation of any law present or future of a provincial legislature in relation to any such matter.
+
+\[Note: Substituted by the [*Constitution Act, 1964*](https://primarydocuments.ca/constitution-act-1964/) (No. 38 *infra*) for the section 94A that was originally added by the [*British North America Act, 1951*](https://primarydocuments.ca/633/) (No. 35 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 94A.” less=”Hide”\]Documents related to section 94A:\[posts-by-tag tags = “Section 94A” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Agriculture and Immigration*
+
+95\. In each Province the Legislature may make Laws in relation to Agriculture in the Province, and to Immigration into the Province; and it is hereby declared that the Parliament of Canada may from Time to Time make Laws in relation to Agriculture in all or any of the Provinces, and to Immigration into all or any of the Provinces; and any Law of the Legislature of a Province relative to Agriculture or to Immigration shall have effect in and for the Province as long and as far only as it is not repugnant to any Act of the Parliament of Canada.
+
+\[show\_more more=”Click here for documents related to section 95.” less=”Hide”\]Documents related to section 95:\[posts-by-tag tags = “Section 95” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### VII. JUDICATURE
+
+\[show\_more more=”Click here for documents related to Part VII.” less=”Hide”\]Documents related to Part VII:\[posts-by-tag tags = “Part VII” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+96\. The Governor General shall appoint the Judges of the Superior, District, and County Courts in each Province, except those of the Courts of Probate in Nova Scotia and New Brunswick.
+
+\[show\_more more=”Click here for documents related to section 96.” less=”Hide”\]Documents related to section 96:\[posts-by-tag tags = “Section 96” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+97\. Until the Laws relative to Property and Civil Rights in Ontario, Nova Scotia, and New Brunswick, and the Procedure of the Courts in those Provinces, are made uniform, the Judges of the Courts of those Provinces appointed by the Governor General shall be selected from the respective Bars of those Provinces.
+
+\[show\_more more=”Click here for documents related to section 97.” less=”Hide”\]Documents related to section 97:\[posts-by-tag tags = “Section 97” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+98\. The Judges of the Courts of Quebec shall be selected from the Bar of that Province.
+
+\[show\_more more=”Click here for documents related to section 98.” less=”Hide”\]Documents related to section 98:\[posts-by-tag tags = “Section 98” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+99\. The Judges of the Superior Courts shall hold Office during good Behaviour, but shall be removable by the Governor General on Address of the Senate and House of Commons.
+
+99\. (1) Subject to subsection (2) of this section, the judges of the superior courts shall hold office during good behaviour, but shall be removable by the Governor General on address of the Senate and House of Commons.
+
+(2) A judge of a superior court, whether appointed before or after the coming into force of this section, shall cease to hold office upon attaining the age of seventy-five years, or upon the coming into force of this section if at that time he has already attained that age.
+
+\[Note: Section 99 (in italics) was repealed and the new section substituted by the *[Constitution Act, 1960](https://primarydocuments.ca/constitution-act-1960/)* (No. 37 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 99.” less=”Hide”\]Documents related to section 99:\[posts-by-tag tags = “Section 99” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+100\. The Salaries, Allowances, and Pensions of the Judges of the Superior, District, and County Courts (except the Courts of Probate in Nova Scotia and New Brunswick), and of the Admiralty Courts in Cases where the Judges thereof are for the Time being paid by Salary, shall be fixed and provided by the Parliament of Canada.
+
+\[Note: See the [*Judges Act*](http://laws-lois.justice.gc.ca/eng/acts/J-1/) (Canada).\]  
+\[show\_more more=”Click here for documents related to section 100.” less=”Hide”\]Documents related to section 100:\[posts-by-tag tags = “Section 100” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+101\. The Parliament of Canada may, notwithstanding anything in this Act, from Time to Time provide for the Constitution, Maintenance, and Organization of a General Court of Appeal for Canada, and for the Establishment of any additional Courts for the better Administration of the Laws of Canada.
+
+\[Note: See the *[Supreme Court Act](http://laws-lois.justice.gc.ca/eng/acts/S-26/),* [*Federal Court Act*](http://laws-lois.justice.gc.ca/eng/acts/F-7/) and [*Tax Court of Canada Act*](http://laws-lois.justice.gc.ca/eng/acts/T-2/) (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 101.” less=”Hide”\]Documents related to section 101:\[posts-by-tag tags = “Section 101” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### VIII. REVENUES; DEBTS; ASSETS; TAXATION
+
+\[show\_more more=”Click here for documents related to Part VIII.” less=”Hide”\]Documents related to Part VIII:\[posts-by-tag tags = “Part VIII” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+102\. All Duties and Revenues over which the respective Legislatures of Canada, Nova Scotia, and New Brunswick before and at the Union had and have Power of Appropriation, except such Portions thereof as are by this Act reserved to the respective Legislatures of the Provinces, or are raised by them in accordance with the special Powers conferred on them by this Act, shall form One Consolidated Revenue Fund, to be appropriated for the Public Service of Canada in the Manner and subject to the Charges in this Act provided.
+
+\[show\_more more=”Click here for documents related to section 102.” less=”Hide”\]Documents related to section 102:\[posts-by-tag tags = “Section 102” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+103\. The Consolidated Revenue Fund of Canada shall be permanently charged with the Costs, Charges, and Expenses incident to the Collection, Management, and Receipt thereof, and the same shall form the First Charge thereon, subject to be reviewed and audited in such Manner as shall be ordered by the Governor General in Council until the Parliament otherwise provides.
+
+\[show\_more more=”Click here for documents related to section 103.” less=”Hide”\]Documents related to section 103:\[posts-by-tag tags = “Section 103” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+104\. The annual Interest of the Public Debts of the several Provinces of Canada, Nova Scotia, and New Brunswick at the Union shall form the Second Charge on the Consolidated Revenue Fund of Canada.
+
+\[show\_more more=”Click here for documents related to section 104.” less=”Hide”\]Documents related to section 104:\[posts-by-tag tags = “Section 104” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+105\. Unless altered by the Parliament of Canada, the Salary of the Governor General shall be Ten thousand Pounds Sterling Money of the United Kingdom of Great Britain and Ireland, payable out of the Consolidated Revenue Fund of Canada, and the same shall form the Third Charge thereon.
+
+\[Note: See the [*Governor General’s Act*](http://laws.justice.gc.ca/eng/acts/g-9/) (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 105.” less=”Hide”\]Documents related to section 105:\[posts-by-tag tags = “Section 105” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+106\. Subject to the several Payments by this Act charged on the Consolidated Revenue Fund of Canada, the same shall be appropriated by the Parliament of Canada for the Public Service.
+
+\[show\_more more=”Click here for documents related to section 106.” less=”Hide”\]Documents related to section 106:\[posts-by-tag tags = “Section 106” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+107\. All Stocks, Cash, Banker’s Balances, and Securities for Money belonging to each Province at the Time of the Union, except as in this Act mentioned, shall be the Property of Canada, and shall be taken in Reduction of the Amount of the respective Debts of the Provinces at the Union.
+
+\[show\_more more=”Click here for documents related to section 107.” less=”Hide”\]Documents related to section 107:\[posts-by-tag tags = “Section 107” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+108\. The Public Works and Property of each Province, enumerated in the Third Schedule to this Act, shall be the Property of Canada.
+
+\[show\_more more=”Click here for documents related to section 108.” less=”Hide”\]Documents related to section 108:\[posts-by-tag tags = “Section 108” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+109\. All Lands, Mines, Minerals, and Royalties belonging to the several Provinces of Canada, Nova Scotia, and New Brunswick at the Union, and all Sums then due or payable for such Lands, Mines, Minerals, or Royalties, shall belong to the several Provinces of Ontario, Quebec, Nova Scotia, and New Brunswick in which the same are situate or arise, subject to any Trusts existing in respect thereof, and to any Interest other than that of the Province in the same.
+
+\[Note: The Provinces of Manitoba, British Columbia, Alberta and Saskatchewan were placed in the same position as the original provinces by the [Constitution Act, 1930](https://primarydocuments.ca/constitution-act-1930/) (No. 26 *infra*).
+
+Newfoundland was also placed in the same position by the [*Newfoundland Act*](https://primarydocuments.ca/newfoundland-act/) (No. 32 *infra*).
+
+With respect to Prince Edward Island, see the Schedule to the [*Prince Edward Island Terms of Union*](https://primarydocuments.ca/prince-edward-island-terms-of-union/) (No. 12 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 109.” less=”Hide”\]Documents related to section 109:\[posts-by-tag tags = “Section 109” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+110\. All Assets connected with such Portions of the Public Debt of each Province as are assumed by that Province shall belong to that Province.
+
+\[show\_more more=”Click here for documents related to section 110.” less=”Hide”\]Documents related to section 110:\[posts-by-tag tags = “Section 110” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+111\. Canada shall be liable for the Debts and Liabilities of each Province existing at the Union.
+
+\[show\_more more=”Click here for documents related to section 111.” less=”Hide”\]Documents related to section 111:\[posts-by-tag tags = “Section 111” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+112\. Ontario and Quebec conjointly shall be liable to Canada for the Amount (if any) by which the Debt of the Province of Canada exceeds at the Union Sixty-two million five hundred thousand Dollars, and shall be charged with Interest at the Rate of Five per Centum per Annum thereon.
+
+\[show\_more more=”Click here for documents related to section 112.” less=”Hide”\]Documents related to section 112:\[posts-by-tag tags = “Section 112” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+113\. The Assets enumerated in the Fourth Schedule to this Act belonging at the Union to the Province of Canada shall be the Property of Ontario and Quebec conjointly.
+
+\[show\_more more=”Click here for documents related to section 113.” less=”Hide”\]Documents related to section 113:\[posts-by-tag tags = “Section 113” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+114\. Nova Scotia shall be liable to Canada for the Amount (if any) by which its Public Debt exceeds at the Union Eight million Dollars, and shall be charged with Interest at the Rate of Five per Centum per Annum thereon.
+
+\[Note: As to sections 114, 115 and 116, see the [*Provincial Subsidies Act*](http://laws-lois.justice.gc.ca/eng/acts/P-26/FullText.html) (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 114.” less=”Hide”\]Documents related to section 114:\[posts-by-tag tags = “Section 114” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+115\. New Brunswick shall be liable to Canada for the Amount (if any) by which its Public Debt exceeds at the Union Seven million Dollars, and shall be charged with Interest at the Rate of Five per Centum per Annum thereon.
+
+\[show\_more more=”Click here for documents related to section 115.” less=”Hide”\]Documents related to section 115:\[posts-by-tag tags = “Section 115” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+116\. In case the Public Debts of Nova Scotia and New Brunswick do not at the Union amount to Eight million and Seven million Dollars respectively, they shall respectively receive by half-yearly Payments in advance from the Government of Canada Interest at Five per Centum per Annum on the Difference between the actual Amounts of their respective Debts and such stipulated Amounts.
+
+\[show\_more more=”Click here for documents related to section 116.” less=”Hide”\]Documents related to section 116:\[posts-by-tag tags = “Section 116” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+117\. The several Provinces shall retain all their respective Public Property not otherwise disposed of in this Act, subject to the Right of Canada to assume any Lands or Public Property required for Fortifications or for the Defence of the Country.
+
+\[show\_more more=”Click here for documents related to section 117.” less=”Hide”\]Documents related to section 117:\[posts-by-tag tags = “Section 117” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*118\. The following Sums shall be paid yearly by Canada to the several Provinces for the Support of their Governments and Legislatures:*
+
+|  | *Dollars.* |
+| --- | --- |
+| *Ontario.* | *Eighty thousand.* |
+| *Quebec.* | *Seventy thousand.* |
+| *Nova Scotia.* | *Sixty thousand.* |
+| *New Brunswick.* | *Fifty thousand.* |
+|  | *Two hundred and sixty thousand.* |
+
+*and an annual Grant in aid of each Province shall be made, equal to Eighty Cents per Head of the Population as ascertained by the Census of One thousand eight hundred and sixty-one, and in the Case of Nova Scotia and New Brunswick, by each subsequent Decennial Census until the Population of each of those two Provinces amounts to Four hundred thousand Souls, at which Rate such Grant shall thereafter remain. Such Grants shall be in full Settlement of all future Demands on Canada, and shall be paid half-yearly in advance to each Province; but the Government of Canada shall deduct from such Grants, as against any Province, all Sums chargeable as Interest on the Public Debt of that Province in excess of the several Amounts stipulated in this Act.*
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1950](https://primarydocuments.ca/1950/05/23/statute-law-revision-act-1950/)* (No. 34 *infra*). The section had been previously superseded by the [*Constitution Act, 1907*](https://primarydocuments.ca/1907/08/09/constitution-act-1907/) (No. 22 *infra*). See the [*Provincial Subsidies Act*](http://laws-lois.justice.gc.ca/eng/acts/P-26/FullText.html) and the *[Federal-Provincial Fiscal Arrangements](http://laws-lois.justice.gc.ca/eng/acts/F-8/)* and *[Federal Post-Secondary Education and Health Contributions Act](http://laws-lois.justice.gc.ca/eng/regulations/SOR-87-218/page-1.html)* (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 118.” less=”Hide”\]Documents related to section 118:\[posts-by-tag tags = “Section 118” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+119\. New Brunswick shall receive by half-yearly Payments in advance from Canada for the Period of Ten Years from the Union an additional Allowance of Sixty-three thousand Dollars per Annum; but as long as the Public Debt of that Province remains under Seven million Dollars, a Deduction equal to the Interest at Five per Centum per Annum on such Deficiency shall be made from that Allowance of Sixty-three thousand Dollars.
+
+\[show\_more more=”Click here for documents related to section 119.” less=”Hide”\]Documents related to section 119:\[posts-by-tag tags = “Section 119” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+120\. All Payments to be made under this Act, or in discharge of Liabilities created under any Act of the Provinces of Canada, Nova Scotia, and New Brunswick respectively, and assumed by Canada, shall, until the Parliament of Canada otherwise directs, be made in such Form and Manner as may from Time to Time be ordered by the Governor General in Council.
+
+\[show\_more more=”Click here for documents related to section 120.” less=”Hide”\]Documents related to section 120:\[posts-by-tag tags = “Section 120” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+121\. All Articles of the Growth, Produce, or Manufacture of any one of the Provinces shall, from and after the Union, be admitted free into each of the other Provinces.
+
+\[show\_more more=”Click here for documents related to section 121.” less=”Hide”\]Documents related to section 121:\[posts-by-tag tags = “Section 121” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+122\. The Customs and Excise Laws of each Province shall, subject to the Provisions of this Act, continue in force until altered by the Parliament of Canada.
+
+\[Note: See the current federal [customs](http://laws-lois.justice.gc.ca/eng/acts/C-52.6/) and [excise](http://laws-lois.justice.gc.ca/eng/acts/E-15/) legislation.\]
+
+\[show\_more more=”Click here for documents related to section 122.” less=”Hide”\]Documents related to section 122:\[posts-by-tag tags = “Section 122” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+123\. Where Customs Duties are, at the Union, leviable on any Goods, Wares, or Merchandises in any Two Provinces, those Goods, Wares, and Merchandises may, from and after the Union, be imported from one of those Provinces into the other of them on Proof of Payment of the Customs Duty leviable thereon in the Province of Exportation, and on Payment of such further Amount (if any) of Customs Duty as is leviable thereon in the Province of Importation.
+
+\[show\_more more=”Click here for documents related to section 123.” less=”Hide”\]Documents related to section 123:\[posts-by-tag tags = “Section 123” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+124\. Nothing in this Act shall affect the Right of New Brunswick to levy the Lumber Dues provided in Chapter Fifteen of Title Three of the Revised Statutes of New Brunswick, or in any Act amending that Act before or after the Union, and not increasing the Amount of such Dues; but the Lumber of any of the Provinces other than New Brunswick shall not be subject to such Dues.
+
+\[show\_more more=”Click here for documents related to section 124.” less=”Hide”\]Documents related to section 124:\[posts-by-tag tags = “Section 124” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+125\. No Lands or Property belonging to Canada or any Province shall be liable to Taxation.
+
+\[show\_more more=”Click here for documents related to section 125.” less=”Hide”\]Documents related to section 125:\[posts-by-tag tags = “Section 125” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+126\. Such Portions of the Duties and Revenues over which the respective Legislatures of Canada, Nova Scotia, and New Brunswick had before the Union Power of Appropriation as are by this Act reserved to the respective Governments or Legislatures of the Provinces, and all Duties and Revenues raised by them in accordance with the special Powers conferred upon them by this Act, shall in each Province form One Consolidated Revenue Fund to be appropriated for the Public Service of the Province.
+
+\[show\_more more=”Click here for documents related to section 126.” less=”Hide”\]Documents related to section 126:\[posts-by-tag tags = “Section 126” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### IX. MISCELLANEOUS PROVISIONS
+
+\[show\_more more=”Click here for documents related to Part IX.” less=”Hide”\]Documents related to Part IX:\[posts-by-tag tags = “Part IX” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*General*
+
+127\. If any Person being at the passing of this Act a Member of the Legislative Council of Canada, Nova Scotia, or New Brunswick, to whom a Place in the Senate is offered, does not within Thirty Days thereafter, by Writing under his Hand addressed to the Governor General of the Province of Canada or to the Lieutenant Governor of Nova Scotia or New Brunswick (as the Case may be), accept the same, he shall be deemed to have declined the same; and any Person who, being at the passing of this Act a Member of the Legislative Council of Nova Scotia or New Brunswick, accepts a Place in the Senate, shall thereby vacate his Seat in such Legislative Council.
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 127.” less=”Hide”\]Documents related to section 127:\[posts-by-tag tags = “Section 127” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+128\. Every Member of the Senate or House of Commons of Canada shall before taking his Seat therein take and subscribe before the Governor General or some Person authorized by him, and every Member of a Legislative Council or Legislative Assembly of any Province shall before taking his Seat therein take and subscribe before the Lieutenant Governor of the Province or some Person authorized by him, the Oath of Allegiance contained in the Fifth Schedule to this Act; and every Member of the Senate of Canada and every Member of the Legislative Council of Quebec shall also, before taking his Seat therein, take and subscribe before the Governor General, or some Person authorized by him, the Declaration of Qualification contained in the same Schedule.
+
+\[show\_more more=”Click here for documents related to section 128.” less=”Hide”\]Documents related to section 128:\[posts-by-tag tags = “Section 128” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+129\. Except as otherwise provided by this Act, all Laws in force in Canada, Nova Scotia, or New Brunswick at the Union, and all Courts of Civil and Criminal Jurisdiction, and all legal Commissions, Powers, and Authorities, and all Officers, Judicial, Administrative, and Ministerial, existing therein at the Union, shall continue in Ontario, Quebec, Nova Scotia, and New Brunswick respectively, as if the Union had not been made; subject nevertheless (except with respect to such as are enacted by or exist under Acts of the Parliament. of Great Britain or of the Parliament of the United Kingdom of Great Britain and Ireland,) to be repealed, abolished, or altered by the Parliament of Canada, or by the Legislature of the respective Province, according to the Authority of the Parliament or of that Legislature under this Act.
+
+\[Note: The restriction against altering or repealing laws enacted by or existing under statutes of the United Kingdom was removed by the [*Statute of Westminster, 1931*](https://primarydocuments.ca/statute-of-westminster-1931/) (No. 27 *infra*), except in respect of certain constitutional documents. See also Part V of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 129.” less=”Hide”\]Documents related to section 129:\[posts-by-tag tags = “Section 129” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+130\. Until the Parliament of Canada otherwise provides, all Officers of the several Provinces having Duties to discharge in relation to Matters other than those coming within the Classes of Subjects by this Act assigned exclusively to the Legislatures of the Provinces shall be Officers of Canada, and shall continue to discharge the Duties of their respective Offices under the same Liabilities, Responsibilities, and Penalties as if the Union had not been made.
+
+\[show\_more more=”Click here for documents related to section 130.” less=”Hide”\]Documents related to section 130:\[posts-by-tag tags = “Section 130” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+131\. Until the Parliament of Canada otherwise provides, the Governor General in Council may from Time to Time appoint such Officers as the Governor General in Council deems necessary or proper for the effectual Execution of this Act.
+
+\[show\_more more=”Click here for documents related to section 131.” less=”Hide”\]Documents related to section 131:\[posts-by-tag tags = “Section 131” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+132\. The Parliament and Government of Canada shall have all Powers necessary or proper for performing the Obligations of Canada or of any Province thereof, as Part of the British Empire, towards Foreign Countries, arising under Treaties between the Empire and such Foreign Countries.
+
+\[show\_more more=”Click here for documents related to section 132.” less=”Hide”\]Documents related to section 132:\[posts-by-tag tags = “Section 132” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+133\. Either the English or the French Language may be used by any Person in the Debates of the Houses of the Parliament of Canada and of the Houses of the Legislature of Quebec; and both those Languages shall be used in the respective Records and Journals of those Houses; and either of those Languages may be used by any Person or in any Pleading or Process in or issuing from any Court of Canada established under this Act, and in or from all or any of the Courts of Quebec.
+
+The Acts of the Parliament of Canada and of the Legislature of Quebec shall be printed and published in both those Languages.
+
+\[Note: See also section 23 of the [*Manitoba Act, 1870*](https://primarydocuments.ca/manitoba-act-1870/) (No. 8 *infra*) and sections 17 to 23 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 133.” less=”Hide”\]Documents related to section 133:\[posts-by-tag tags = “Section 133” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+*Ontario and Quebec*
+
+134\. Until the Legislature of Ontario or of Quebec otherwise provides, the Lieutenant Governors of Ontario and Quebec may each appoint under the Great Seal of the Province the following Officers, to hold Office during Pleasure, that is to say,—the Attorney General, the Secretary and Registrar of the Province, the Treasurer of the Province, the Commissioner of Crown Lands, and the Commissioner of Agriculture and Public Works, and in the Case of Quebec the Solicitor General, and may, by Order of the Lieutenant Governor in Council, from Time to Time prescribe the Duties of those Officers, and of the several Departments over which they shall preside or to which they shall belong, and of the Officers and Clerks thereof, and may also appoint other and additional Officers to hold Office during Pleasure, and may from Time to Time prescribe the Duties of those Officers, and of the several Departments over which they shall preside or to which they shall belong, and of the Officers and Clerks thereof.
+
+\[Note: See the [*Executive Council Act* (Ontario)](https://www.ontario.ca/laws/statute/90e25) and the [*Executive Power Act* (Quebec)](http://legisquebec.gouv.qc.ca/en/ShowDoc/cs/E-18).\]
+
+\[show\_more more=”Click here for documents related to section 134.” less=”Hide”\]Documents related to section 134:\[posts-by-tag tags = “Section 134” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+135\. Until the Legislature of Ontario or Quebec otherwise provides, all Rights, Powers, Duties, Functions, Responsibilities, or Authorities at the passing of this Act vested in or imposed on the Attorney General, Solicitor General, Secretary and Registrar of the Province of Canada, Minister of Finance, Commissioner of Crown Lands, Commissioner of Public Works, and Minister of Agriculture and Receiver General, by any Law, Statute, or Ordinance of Upper Canada, Lower Canada, or Canada, and not repugnant to this Act, shall be vested in or imposed on any Officer to be appointed by the Lieutenant Governor for the Discharge of the same or any of them; and the Commissioner of Agriculture and Public Works shall perform the Duties and Functions of the Office of Minister of Agriculture at the passing of this Act imposed by the Law of the Province of Canada, as well as those of the Commissioner of Public Works.
+
+\[show\_more more=”Click here for documents related to section 135.” less=”Hide”\]Documents related to section 135:\[posts-by-tag tags = “Section 135” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+136\. Until altered by the Lieutenant Governor in Council, the Great Seals of Ontario and Quebec respectively shall be the same, or of the same Design, as those used in the Provinces of Upper Canada and Lower Canada respectively before their Union as the Province of Canada.
+
+\[show\_more more=”Click here for documents related to section 136.” less=”Hide”\]Documents related to section 136:\[posts-by-tag tags = “Section 136” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+137\. The Words “and from thence to the End of the then next ensuing Session of the Legislature,” or Words to the same Effect, used in any temporary Act of the Province of Canada not expired before the Union, shall be construed to extend and apply to the next Session of the Parliament of Canada if the Subject Matter of the Act is within the Powers of the same as defined by this Act, or to the next Sessions of the Legislatures of Ontario and Quebec respectively if the Subject Matter of the Act is within the Powers of the same as defined by this Act.
+
+\[show\_more more=”Click here for documents related to section 137.” less=”Hide”\]Documents related to section 137:\[posts-by-tag tags = “Section 137” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+138\. From and after the Union the Use of the Words “Upper Canada” instead of “Ontario,” or “Lower Canada” instead of “Quebec,” in any Deed, Writ, Process, Pleading, Document, Matter, or Thing, shall not invalidate the same.
+
+\[show\_more more=”Click here for documents related to section 138.” less=”Hide”\]Documents related to section 138:\[posts-by-tag tags = “Section 138” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+139\. Any Proclamation under the Great Seal of the Province of Canada issued before the Union to take effect at a Time which is subsequent to the Union, whether relating to that Province, or to Upper Canada, or to Lower Canada, and the several Matters and Things therein proclaimed, shall be and continue of like Force and Effect as if the Union had not been made.
+
+\[show\_more more=”Click here for documents related to section 139.” less=”Hide”\]Documents related to section 139:\[posts-by-tag tags = “Section 139” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+140\. Any Proclamation which is authorized by any Act of the Legislature of the Province of Canada to be issued under the Great Seal of the Province of Canada, whether relating to that Province, or to Upper Canada, or to Lower Canada, and which is not issued before the Union, may be issued by the Lieutenant Governor of Ontario or of Quebec, as its Subject Matter requires, under the Great Seal thereof; and from and after the Issue of such Proclamation the same and the several Matters and Things therein proclaimed shall be and continue of the like Force and Effect in Ontario or Quebec as if the Union had not been made.
+
+\[show\_more more=”Click here for documents related to section 140.” less=”Hide”\]Documents related to section 140:\[posts-by-tag tags = “Section 140” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+141\. The Penitentiary of the Province of Canada shall, until the Parliament of Canada otherwise provides, be and continue the Penitentiary of Ontario and of Quebec.
+
+\[Note: See the *Penitentiary Act* (Canada).\]
+
+\[show\_more more=”Click here for documents related to section 141.” less=”Hide”\]Documents related to section 141:\[posts-by-tag tags = “Section 141” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+142\. The Division and Adjustment of the Debts, Credits, Liabilities, Properties, and Assets of Upper Canada and Lower Canada shall be referred to the Arbitrament of Three Arbitrators, One chosen by the Government of Ontario, One by the Government of Quebec, and One by the Government of Canada; and the Selection of the Arbitrators shall not be made until the Parliament of Canada and the Legislatures of Ontario and Quebec have met; and the Arbitrator chosen by the Government of Canada shall not be a Resident either in Ontario or in Quebec.
+
+\[show\_more more=”Click here for documents related to section 142.” less=”Hide”\]Documents related to section 142:\[posts-by-tag tags = “Section 142” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+143\. The Governor General in Council may from Time to Time order that such and so many of the Records, Books, and Documents of the Province of Canada as he thinks fit shall be appropriated and delivered either to Ontario or to Quebec, and the same shall thenceforth be the Property of that Province; and any Copy thereof or Extract therefrom, duly certified by the Officer having charge of the Original thereof, shall be admitted as Evidence.
+
+\[show\_more more=”Click here for documents related to section 143.” less=”Hide”\]Documents related to section 143:\[posts-by-tag tags = “Section 143” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+144\. The Lieutenant Governor of Quebec may from Time to Time, by Proclamation under the Great Seal of the Province, to take effect from a Day to be appointed therein, constitute Townships in those Parts of the Province of Quebec in which Townships are not then already constituted, and fix the Metes and Bounds thereof.
+
+\[show\_more more=”Click here for documents related to section 144.” less=”Hide”\]Documents related to section 144:\[posts-by-tag tags = “Section 144” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### X. INTERCOLONIAL RAILWAY
+
+\[show\_more more=”Click here for documents related to Part X.” less=”Hide”\]Documents related to Part X:\[posts-by-tag tags = “Part X” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+145\. Inasmuch as the Provinces of Canada, Nova Scotia, and New Brunswick have joined in a Declaration that the Construction “of the Intercolonial Railway is essential to the Consolidation of the Union of British North America, and to the Assent thereto of Nova Scotia and New Brunswick, and have consequently agreed that Provision should be made for its immediate Construction by the Government of Canada: Therefore, in order to give effect to that Agreement, it shall be the Duty of the Government and Parliament of Canada to provide for the Commencement, within Six Months after the Union, of a Railway connecting the River St. Lawrence with the City of Halifax in Nova Scotia, and for the Construction thereof without Intermission, and the Completion thereofwith all practicable Speed.
+
+\[Note: Repealed by the *[Statute Law Revision Act, 1893](https://primarydocuments.ca/statute-law-revision-act-1893/)* (No. 17 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 145.” less=”Hide”\]Documents related to section 145:\[posts-by-tag tags = “Section 145” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+### XI. ADMISSION OF OTHER COLONIES
+
+\[show\_more more=”Click here for documents related to Part XI.” less=”Hide”\]Documents related to Part XI:\[posts-by-tag tags = “Part XI” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+146\. It shall be lawful for the Queen, by and with the Advice of Her Majesty’s Most Honourable Privy Council, on Addresses from the Houses of the Parliament of Canada, and from the Houses of the respective Legislatures of the Colonies or Provinces of Newfoundland, Prince Edward Island, and British Columbia, to admit those Colonies or Provinces, or any of them, into the Union, and on Address from the Houses of the Parliament of Canada to admit Rupert’s Land and the North-western Territory, or either of them, into the Union, on such Terms and Conditions in each Case as are in the Addresses expressed and as the Queen thinks fit to approve, subject to the Provisions of this Act; and the Provisions of any Order in Council in that Behalf shall have effect as if they had been enacted by the Parliament of the United Kingdom of Great Britain and Ireland.
+
+\[Note: Rupert’s Land and the North-Western Territory (subsequently designated the Northwest Territories) became part of Canada, pursuant to this section and the [*Rupert’s Land Act, 1868*](https://primarydocuments.ca/ruperts-land-act-1868/) (No. 6 *infra*), by the *[Rupert’s Land and North-Western Territory Order](https://primarydocuments.ca/ruperts-land-and-north-western-territory-order/)* (June 23, 1870) (No. 9 *infra*).
+
+The Province of Manitoba was established by the [*Manitoba Act, 1870*](https://primarydocuments.ca/manitoba-act-1870/) (No. 8 *infra*). This Act was confirmed by the *[Constitution Act, 1871](https://primarydocuments.ca/constitution-act-1871/)* (No. 11 *infra*).
+
+British Columbia was admitted into the Union pursuant to this section by the [*British Columbia Terms of Union*](https://primarydocuments.ca/british-columbia-terms-of-union/) (May 16, 1871) (No. 10 *infra*).
+
+Prince Edward Island was admitted into the Union pursuant to this section by the [*Prince Edward Island Terms of Union*](https://primarydocuments.ca/prince-edward-island-terms-of-union/) (June 26, 1873) (No. 12 *infra*).
+
+The Provinces of Alberta and Saskatchewan were established, pursuant to the *[Constitution Act, 1871](https://primarydocuments.ca/constitution-act-1871/)* (No. 11 *infra*), by the [*Alberta Act*](https://primarydocuments.ca/alberta-act/) (July 20, 1905) (No. 20 *infra*) and the *[Saskatchewan Act](https://primarydocuments.ca/saskatchewan-act/)* (July 20, 1905) (No. 21 *infra*) respectively.
+
+Newfoundland was admitted as a province by the [*Newfoundland Act*](https://primarydocuments.ca/newfoundland-act/) (March 23, 1949) (No. 32 *infra*), which confirmed the Agreement containing the Terms of Union between Canada and Newfoundland.
+
+The Yukon Territory was created out of the Northwest Territories in 1898 by the [*Yukon Territory Act*](https://primarydocuments.ca/yukon-territory-act/) (No. 19 *infra*).\]
+
+\[show\_more more=”Click here for documents related to section 146.” less=”Hide”\]Documents related to section 146:\[posts-by-tag tags = “Section 146” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+147\. In case of the Admission of Newfoundland and Prince Edward Island, or either of them, each shall be entitled to a Representation in the Senate of Canada of Four Members, and (notwithstanding anything in this Act) in case of the Admission of Newfoundland the normal Number of Senators shall be Seventy-six and their maximum Number shall be Eighty-two; but Prince Edward Island when admitted shall be deemed to be comprised in the third of the Three Divisions into which Canada is, in relation to the Constitution of the Senate, divided by this Act, and accordingly, after the Admission of Prince Edward Island, whether Newfoundland is admitted or not, the Representation of Nova Scotia and New Brunswick in the Senate shall, as Vacancies occur, be reduced from Twelve to Ten Members respectively, and the Representation of each of those Provinces shall not be increased at any Time beyond Ten, except under the Provisions of this Act for the Appointment of Three or Six additional Senators under the Direction of the Queen.
+
+\[Note: See the notes to sections [21](https://primarydocuments.ca/constitution/#s-21), [22](https://primarydocuments.ca/constitution/#s-22), [26](https://primarydocuments.ca/constitution/#s-26), [27](https://primarydocuments.ca/constitution/#s-27) and [28](https://primarydocuments.ca/constitution/#s-28).\]
+
+\[show\_more more=”Click here for documents related to section 147.” less=”Hide”\]Documents related to section 147:\[posts-by-tag tags = “Section 147” number = 999\]\[/posts-by-tag\]\[/show\_more\]
+
+---
+
+### SCHEDULES
+
+The FIRST SCHEDULE
+
+*Electoral Districts of Ontario*
+
+A
+
+EXISTING ELECTORAL DIVISIONS
+
+COUNTIES
+
+1\. Prescott.  
+2\. Glengarry.  
+3\. Stormont.  
+4\. Dundas.  
+5\. Russell.  
+6\. Carleton  
+7\. Prince Edward  
+8\. Halton  
+9\. Essex.
+
+RIDINGS OF COUNTIES
+
+10\. North Riding of Lanark.  
+11\. South Riding of Lanark.  
+12\. North Riding of Leeds and North Riding of Grenville.  
+13\. South Riding of Leeds.  
+14\. South Riding of Grenville.  
+15\. East Riding of Northumberland.  
+16\. West Riding of Northumberland (excepting therefrom the Township of South Monaghan).  
+17\. East Riding of Durham.  
+18\. West Riding of Durham.  
+19\. North Riding of Ontario.  
+20\. South Riding of Ontario.  
+21\. East Riding of York.  
+22\. West Riding of York.  
+23\. North Riding of York.  
+24\. North Riding of Wentworth.  
+25\. South Riding of Wentworth.  
+26\. East Riding of Elgin.  
+27\. West Riding of Elgin.  
+28\. North Riding of Waterloo.  
+29\. South Riding of Waterloo.  
+30\. North Riding of Brant.  
+31\. South Riding of Brant.  
+32\. North Riding of Oxford.  
+33\. South Riding of Oxford.  
+34\. East Riding of Middlesex.
+
+CITIES, PARTS OF CITIES, AND TOWNS
+
+35\. West Toronto.  
+36\. East Toronto.  
+37\. Hamilton.  
+38\. Ottawa.  
+39\. Kingston.  
+40\. London.  
+41\. Town of Brockville, with the Township of Elizabethtown thereto attached.  
+42\. Town of Niagara, with the Township of Niagara thereto attached.  
+43\. Town of Cornwall, with the Township of Cornwall thereto attached.
+
+B
+
+NEW ELECTORAL DIVISIONS
+
+44\. The Provisional Judicial District of ALGOMA.
+
+The County of BRUCE, divided into Two Ridings, to be called respectively the North and South Ridings:—
+
+45\. The North Riding of Bruce to consist of the Townships of Bury, Lindsay, Eastnor, Albermarle, Amabel, Arran, Bruce, Elderslie, and Saugeen, and the Village of Southampton.
+
+46\. The South Riding of Bruce to consist of the Townships of Kincardine (including the Village of Kincardine), Greenock, Brant, Huron, Kinloss, Culross, and Carrick.
+
+The County of HURON, divided into Two Ridings, to be called respectively the North and South Ridings:—
+
+47\. The North Riding to consist of the Townships of Ashfield, Wawanosh, Turnberry, Howick, Morris, Grey, Colborne, Hullett, including the Village of Clinton, and McKillop.
+
+48\. The South Riding to consist of the Town of Goderich and the Townships of Goderich, Tuckersmith, Stanley, Hay, Usborne, and Stephen.
+
+The County of MIDDLESEX, divided into three Ridings, to be called respectively the North, West and East Ridings:—
+
+49\. The North Riding to consist of the Townships of McGillivray and Biddulph (taken from the County of Huron), and Williams East, Williams West, Adelaide, and Lobo.
+
+50\. The West Riding to consist of the Townships of Delaware, Carradoc, Metcalfe, Mosa and Ekfrid, and the Village of Strathroy.
+
+\[The East Riding to consist of the Townships now embraced therein, and be. bounded as it is at present.\]
+
+51\. The County of LAMBTON to consist of the Townships of Bosanquet, Warwick, Plympton, Sarnia, Moore, Enniskillen, and Brooke, and the Town of Sarnia.
+
+52\. The County of KENT to consist of the Townships of Chatham, Dover, East Tilbury, Romney, Raleigh, and Harwich, and the Town of Chatham.
+
+53\. The County of BOTHWELL to consist of the Townships of Sombra, Dawn, and Euphemia (taken from the County of Lambton), and the Townships of Zone, Camden with the Gore thereof, Orford, and Howard (taken from the County of Kent).
+
+The County of GREY, divided into Two Ridings, to be called respectively the South and North Ridings:—
+
+54\. The South Riding to consist of the Townships of Bentinck, Glenelg, Artemesia, Osprey, Normanby, Egremont, Proton, and Melancthon.
+
+55\. The North Riding to consist of the Townships of Collingwood, Euphrasia, Holland, Saint-Vincent, Sydenham, Sullivan, Derby, and Keppel, Sarawak and Brooke, and the Town of Owen Sound.
+
+The County of PERTH, divided into Two Ridings, to be called respectively the South and North Ridings:-
+
+56\. The North Riding to consist of the Townships of Wallace, Elma, Logan, Ellice, Mornington, and North Easthope, and the Town of Stratford.
+
+57\. The South Riding to consist of the Townships of Blanchard, Downie, South Easthope, Fullarton, Hibbert, and the Villages of Mitchell and Ste. Marys.
+
+The County of WELLINGTON, divided into Three Ridings, to be called respectively North, South and Centre Ridings:—
+
+58\. The North Riding to consist of the Townships of Amaranth, Arthur, Luther, Minto, Maryborough, Peel, and the Village of Mount Forest.
+
+59\. The Centre Riding to consist of the Townships of Garafraxa, Erin, Eramosa, Nichol, and Pilkington, and the Villages of Fergus and Elora.
+
+60\. The South Riding to consist of the Town of Guelph, and the Townships of Guelph and Puslinch.
+
+The County of NORFOLK, divided into Two Ridings, to be called respectively the South and North Ridings:—
+
+61\. The South Riding to consist of the Townships of Charlotteville, Houghton, Walsingham, and Woodhouse and with the Gore thereof.
+
+62\. The North Riding to consist of the Townships of Middleton, Townsend, and Windham, and the Town of Simcoe.
+
+63\. The County of HALDIMAND to consist of the Townships of Oneida, Seneca, Cayuga North, Cayuga South, Rayn- ham, Walpole, and Dunn.
+
+64\. The County of MONCK to consist of the Townships of Canborough and Moulton, and Sherbrooke, and the Village of Dunnville (taken from the County of Haldimand), the Townships of Caistor and Gainsborough (taken from the County of Lincoln), and the Townships of Pelham and Wainfleet (taken from the County of Welland).
+
+65\. The County of LINCOLN to consist of the Townships of Clinton, Grantham, Grimsby, and Louth, and the Town of St. Catherines.
+
+66\. The County of WELLAND to consist of the Townships of Bertie, Crowland, Humberstone, Stamford, Thorold, and Willoughby, and the Villages of Chippewa, Clifton, Fort Erie, Thorold, and Welland.
+
+67\. The County of PEEL to consist of the Townships of Chinguacousy, Toronto, and the Gore of Toronto, and the Villages of Brampton and Streetsville.
+
+68\. The County of CARDWELL to consist of the Townships of Albion and Caledon (taken from the County of Peel), and the Townships of Adjala and Mono (taken from the County of Simcoe).
+
+The County of SIMCOE, divided into Two Ridings, to be called respectively the South and North Ridings:—
+
+69\. The South Riding to consist of the Townships of West Gwillimbury, Tecumseth, Innisfil, Essa, Tosorontio, Mulmur, and the Village of Bradford.
+
+70\. The North Riding to consist of the Townships of Nottawasaga, Sunnidale, Vespra, Flos, Oro, Medonte, Orillia and Matchedash, Tiny and Tay, Balaklava and Robinson, and the Towns of Barrie and Collingwood.
+
+The County of VICTORIA, divided into Two Ridings, to be called respectively the South and North Ridings:—
+
+71\. The South Riding to consist of the Townships of Ops, Mariposa, Emily, Verulam, and the Town of Lindsay.
+
+72\. The North Riding to consist of the Townships of Anson, Bexley, Carden, Dalton, Digby, Eldon, Fenelon, Hindon, Laxton, Lutterworth, Macaulay and Draper, Sommerville, and Morrison, Muskoka, Monck and Watt (taken from the County of Simcoe), and any other surveyed Townships lying to the North of the said North Riding.
+
+The County of PETERBOROUGH, divided into Two Ridings, to be called respectively the West and East Ridings:—
+
+73\. The West Riding to consist of the Townships of South Monaghan (taken from the County of Northumberland), North Monaghan, Smith, and Ennismore, and the Town of Peterborough.
+
+74\. The East Riding to consist of the Townships of Asphodel, Belmont and Methuen, Douro, Dummer, Galway, Harvey, Minden, Stanhope and Dysart, Otonabee, and Snowden, and the Village of Ashburnham, and any other surveyed Townships lying to the North of the said East Riding.
+
+The County of HASTINGS, divided into Three Ridings, to be called respectively the West, East, and North Ridings:—
+
+75\. The West Riding to consist of the Town of Belleville, the Township of Sydney, and the Village of Trenton.
+
+76\. The East Riding to consist of the Townships of Thurlow, Tyendinaga, and Hungerford.
+
+77\. The North Riding to consist of the Townships of Rawdon, Huntingdon, Madoc, Elzevir, Tudor, Marmora, and Lake, and the Village of Stirling, and any other surveyed Townships lying to the North of the said North Riding.
+
+78\. The County of LENNOX, to consist of the Townships of Richmond, Adolphustown, North Fredericksburg, South Fredericksburg, Ernest Town, and Amherst Island, and the Village of Napanee.
+
+79\. The County of ADDINGTON to consist of the Townships of Camden, Portland, Sheffield, Hinchinbrooke, Kaladar, Kennebec, Olden, Oso, Anglesea, Barrie, Clarendon, Palmerston, Effingham, Abinger, Miller, Canonto, Denbigh, Loughborough, and Bedford.
+
+80\. The County of FRONTENAC to consist of the Townships of Kingston, Wolfe Island, Pittsburg and Howe Island, and Storrington.
+
+The County of RENFREW, divided into two Ridings, to be called respectively the South and North Ridings:-
+
+81\. The South Riding to consist of the Townships of McNab, Bagot, Blithfield, Brougham, Horton, Admaston, Grattan, Matawatchan, Griffith, Lyndoch, Raglan, Radcliffe, Brudenell, Sebastopol, and the Villages of Arnprior and Renfrew.
+
+82\. The North Riding to consist of the Townships of Ross, Bromley, Westmeath, Stafford, Pembroke, Wilberforce, Alice, Petawawa, Buchanan, South Algona, North Algona, Fraser, McKay, Wylie, Rolph, Head, Maria, Clara, Haggerty, Sherwood, Burns, and Richards, and any other surveyed Townships lying North-westerly of the said North Riding.
+
+Every Town and incorporated Village existing at the Union, not especially mentioned in this Schedule, is to be taken as Part of the County or Riding within which it is locally situate.
+
+The SECOND SCHEDULE
+
+*Electoral Districts of Quebec specially fixed*
+
+COUNTIES OF—
+
+Pontiac.  
+Ottawa.  
+Argenteuil.  
+Huntingdon.  
+Mississquoi.  
+Brome.  
+Shefford.  
+Stanstead.  
+Compton.  
+Wolfe and Richmond.  
+Megantic.
+
+Town of Sherbrooke.
+
+The THIRD SCHEDULE
+
+*Provincial Public Works and Property to be the Property of Canada*
+
+1\. Canals, with Lands and Water Power connected therewith.
+
+2\. Public Harbours.
+
+3\. Lighthouses and Piers, and Sable Island.
+
+4\. Steamboats, Dredges, and public Vessels.
+
+5\. Rivers and Lake Improvements.
+
+6\. Railways and Railway Stocks, Mortgages, and other Debts due by Railway Companies.
+
+7\. Military Roads.
+
+8\. Custom Houses, Post Offices, and all other Public Buildings, except such as the Government of Canada appropriate for the Use of the Provincial Legislatures and Governments.
+
+9\. Property transferred by the Imperial Government, and known as Ordnance Property.
+
+10\. Armouries, Drill Sheds, Military Clothing, and Munitions of War, and Lands set apart for general Public Purposes.
+
+The FOURTH SCHEDULE
+
+*Assets to be the Property of Ontario and Quebec conjointly*
+
+Upper Canada Building Fund.  
+Lunatic Asylums.  
+Normal School.  
+Court Houses in  
+Aylmer,  
+Montreal, Lower Canada  
+Kamouraska,  
+Law Society, Upper Canada.  
+Montreal Turnpike Trust.  
+University Permanent Fund.  
+Royal Institution.  
+Consolidated Municipal Loan Fund, Upper Canada.  
+Consolidated Municipal Loan Fund, Lower Canada.  
+Agricultural Society, Upper Canada.  
+Lower Canada Legislative Grant.  
+Quebec Fire Loan.  
+Temiscouata Advance Account.  
+Quebec Turnpike Trust.  
+Education—East.  
+Building and Jury Fund, Lower Canada.  
+Municipalities Fund.  
+Lower Canada Superior Education Income Fund.
+
+The FIFTH SCHEDULE
+
+OATH OF ALLEGIANCE
+
+I A.B. do swear, That I will be faithful and bear true Allegiance to Her Majesty Queen Victoria.
+
+*Note.—The Name of the King or Queen of the United Kingdom of Great Britain and Ireland for the Time being is to be substituted from Time to Time, with proper Terms of Reference thereto.*
+
+DECLARATION OF QUALIFICATION
+
+I A.B. do declare and testify, That I am by Law duly qualified to be appointed a Member of the Senate of Canada \[*or as the Case may be*\], and that I am legally or equitably seised as of Freehold for my own Use and Benefit of Lands or Tenements held in Free and Common Socage \[*or* seised or possessed for my own Use and Benefit of Lands or Tenements held in Franc-alleu or in Roture (*as the Case may be*),\] in the Province of Nova Scotia \[or as the Case may be\] of the Value of Four thousand Dollars over and above all Rents, Dues, Debts, Mortgages, Charges, and Incumbrances due or payable out of or charged on or affecting the same, and that I have not collusively or colourably obtained a Title to or become possessed of the said Lands and Tenements or any Part thereof for the Purpose of enabling me to become a Member of the Senate of Canada \[*or as the Case may be*\], and that my Real and Personal Property are together worth Four thousand Dollars over and above my Debts and Liabilities.
+
+THE SIXTH SCHEDULE
+
+*Primary Production from Non-Renewable Natural Resources  
+and Forestry Resources*
+
+1\. For the purposes of section 92A of this Act,
+
+(a) production from a non-renewable natural resource is primary production therefrom if  
+(i) it is in the form in which it exists upon its recovery of severance from its natural state, or  
+(ii) it is a product resulting from processing or refining the resource, and is not a manufactured product or a product resulting from refining crude oil, refining upgraded heavy crude oil, refining gases or liquids derived from coal or refining a synthetic equivalent of crude oil; and
+
+(b) production from a forestry resource is primary production therefrom if it consists of sawlogs, poles, lumber, wood chips, sawdust or any other primary wood product, or wood pulp, and is not a product manufactured from wood.
+
+\[Note: The sixth schedule was added by section 51 of the [*Constitution Act, 1982*](https://primarydocuments.ca/constitution-act-1982/) (No. 44 *infra*).\]
+
+---

--- a/test-data/Full_Text_of_the_U.S._Constitution.md
+++ b/test-data/Full_Text_of_the_U.S._Constitution.md
@@ -1,0 +1,541 @@
+---
+title: "Full Text of the U.S. Constitution"
+source: "https://constitutioncenter.org/the-constitution/full-text"
+author:
+  - "[[National Constitution Center – constitutioncenter.org]]"
+published:
+created: 2026-04-08
+description: "Read and share the complete text of the United States Constitution."
+tags:
+  - "clippings"
+---
+
+###### Share
+
+We the People of the United States, in Order to form a more perfect Union, establish Justice, insure domestic Tranquility, provide for the common defence, promote the general Welfare, and secure the Blessings of Liberty to ourselves and our Posterity, do ordain and establish this Constitution for the United States of America.
+
+## The Constitutional Convention
+
+---
+
+## Article I
+
+##### Section 1: Congress
+
+All legislative Powers herein granted shall be vested in a Congress of the United States, which shall consist of a Senate and House of Representatives.
+
+##### Section 2: The House of Representatives
+
+The House of Representatives shall be composed of Members chosen every second Year by the People of the several States, and the Electors in each State shall have the Qualifications requisite for Electors of the most numerous Branch of the State Legislature.
+
+No Person shall be a Representative who shall not have attained to the Age of twenty five Years, and been seven Years a Citizen of the United States, and who shall not, when elected, be an Inhabitant of that State in which he shall be chosen.
+
+Representatives and direct Taxes shall be apportioned among the several States which may be included within this Union, according to their respective Numbers, which shall be determined by adding to the whole Number of free Persons, including those bound to Service for a Term of Years, and excluding Indians not taxed, three fifths of all other Persons. The actual Enumeration shall be made within three Years after the first Meeting of the Congress of the United States, and within every subsequent Term of ten Years, in such Manner as they shall by Law direct.The Number of Representatives shall not exceed one for every thirty Thousand, but each State shall have at Least one Representative; and until such enumeration shall be made, the State of New Hampshire shall be entitled to chuse three, Massachusetts eight, Rhode-Island and Providence Plantations one, Connecticut five, New-York six, New Jersey four, Pennsylvania eight, Delaware one, Maryland six, Virginia ten, North Carolina five, South Carolina five, and Georgia three.
+
+When vacancies happen in the Representation from any State, the Executive Authority thereof shall issue Writs of Election to fill such Vacancies.
+
+The House of Representatives shall chuse their Speaker and other Officers;and shall have the sole Power of Impeachment.
+
+##### Section 3: The Senate
+
+The Senate of the United States shall be composed of two Senators from each State, chosen by the Legislature thereof, for six Years; and each Senator shall have one Vote.
+
+Immediately after they shall be assembled in Consequence of the first Election, they shall be divided as equally as may be into three Classes. The Seats of the Senators of the first Class shall be vacated at the Expiration of the second Year, of the second Class at the Expiration of the fourth Year, and of the third Class at the Expiration of the sixth Year, so that one third may be chosen every second Year; and if Vacancies happen by Resignation, or otherwise, during the Recess of the Legislature of any State, the Executive thereof may make temporary Appointments until the next Meeting of the Legislature, which shall then fill such Vacancies.
+
+No Person shall be a Senator who shall not have attained to the Age of thirty Years, and been nine Years a Citizen of the United States, and who shall not, when elected, be an Inhabitant of that State for which he shall be chosen.
+
+The Vice President of the United States shall be President of the Senate, but shall have no Vote, unless they be equally divided.
+
+The Senate shall chuse their other Officers, and also a President pro tempore, in the Absence of the Vice President, or when he shall exercise the Office of President of the United States.
+
+The Senate shall have the sole Power to try all Impeachments. When sitting for that Purpose, they shall be on Oath or Affirmation. When the President of the United States is tried, the Chief Justice shall preside: And no Person shall be convicted without the Concurrence of two thirds of the Members present.
+
+Judgment in Cases of Impeachment shall not extend further than to removal from Office, and disqualification to hold and enjoy any Office of honor, Trust or Profit under the United States: but the Party convicted shall nevertheless be liable and subject to Indictment, Trial, Judgment and Punishment, according to Law.
+
+##### Section 4: Elections
+
+The Times, Places and Manner of holding Elections for Senators and Representatives, shall be prescribed in each State by the Legislature thereof; but the Congress may at any time by Law make or alter such Regulations, except as to the Places of chusing Senators.
+
+The Congress shall assemble at least once in every Year, and such Meeting shall be on the first Monday in December, unless they shall by Law appoint a different Day.
+
+##### Section 5: Powers and Duties of Congress
+
+Each House shall be the Judge of the Elections, Returns and Qualifications of its own Members,and a Majority of each shall constitute a Quorum to do Business; but a smaller Number may adjourn from day to day, and may be authorized to compel the Attendance of absent Members, in such Manner, and under such Penalties as each House may provide.
+
+Each House may determine the Rules of its Proceedings, punish its Members for disorderly Behaviour, and, with the Concurrence of two thirds, expel a Member.
+
+Each House shall keep a Journal of its Proceedings, and from time to time publish the same, excepting such Parts as may in their Judgment require Secrecy; and the Yeas and Nays of the Members of either House on any question shall, at the Desire of one fifth of those Present, be entered on the Journal.
+
+Neither House, during the Session of Congress, shall, without the Consent of the other, adjourn for more than three days, nor to any other Place than that in which the two Houses shall be sitting.
+
+##### Section 6: Rights and Disabilities of Members
+
+The Senators and Representatives shall receive a Compensation for their Services, to be ascertained by Law, and paid out of the Treasury of the United States.They shall in all Cases, except Treason, Felony and Breach of the Peace, be privileged from Arrest during their Attendance at the Session of their respective Houses, and in going to and returning from the same; and for any Speech or Debate in either House, they shall not be questioned in any other Place.
+
+No Senator or Representative shall, during the Time for which he was elected, be appointed to any civil Office under the Authority of the United States, which shall have been created, or the Emoluments whereof shall have been encreased during such time; and no Person holding any Office under the United States, shall be a Member of either House during his Continuance in Office.
+
+##### Section 7: Legislative Process
+
+All Bills for raising Revenue shall originate in the House of Representatives; but the Senate may propose or concur with Amendments as on other Bills.
+
+Every Bill which shall have passed the House of Representatives and the Senate, shall, before it become a Law, be presented to the President of the United States; If he approve he shall sign it, but if not he shall return it, with his Objections to that House in which it shall have originated, who shall enter the Objections at large on their Journal, and proceed to reconsider it. If after such Reconsideration two thirds of that House shall agree to pass the Bill, it shall be sent, together with the Objections, to the other House, by which it shall likewise be reconsidered, and if approved by two thirds of that House, it shall become a Law. But in all such Cases the Votes of both Houses shall be determined by yeas and Nays, and the Names of the Persons voting for and against the Bill shall be entered on the Journal of each House respectively. If any Bill shall not be returned by the President within ten Days (Sundays excepted) after it shall have been presented to him, the Same shall be a Law, in like Manner as if he had signed it, unless the Congress by their Adjournment prevent its Return, in which Case it shall not be a Law.
+
+Every Order, Resolution, or Vote to which the Concurrence of the Senate and House of Representatives may be necessary (except on a question of Adjournment) shall be presented to the President of the United States; and before the Same shall take Effect, shall be approved by him, or being disapproved by him, shall be repassed by two thirds of the Senate and House of Representatives, according to the Rules and Limitations prescribed in the Case of a Bill.
+
+##### Section 8: Powers of Congress
+
+The Congress shall have Power To lay and collect Taxes, Duties, Imposts and Excises, to pay the Debts and provide for the common Defence and general Welfare of the United States; but all Duties, Imposts and Excises shall be uniform throughout the United States;
+
+To borrow Money on the credit of the United States;
+
+To regulate Commerce with foreign Nations, and among the several States, and with the Indian Tribes;
+
+To establish a uniform Rule of Naturalization, and uniform Laws on the subject of Bankruptcies throughout the United States;
+
+To coin Money, regulate the Value thereof, and of foreign Coin, and fix the Standard of Weights and Measures;
+
+To provide for the Punishment of counterfeiting the Securities and current Coin of the United States;
+
+To establish Post Offices and post Roads;
+
+To promote the Progress of Science and useful Arts, by securing for limited Times to Authors and Inventors the exclusive Right to their respective Writings and Discoveries;
+
+To constitute Tribunals inferior to the supreme Court;
+
+To define and punish Piracies and Felonies committed on the high Seas, and Offences against the Law of Nations;
+
+To declare War, grant Letters of Marque and Reprisal, and make Rules concerning Captures on Land and Water;
+
+To raise and support Armies, but no Appropriation of Money to that Use shall be for a longer Term than two Years;
+
+To provide and maintain a Navy;
+
+To make Rules for the Government and Regulation of the land and naval Forces;
+
+To provide for calling forth the Militia to execute the Laws of the Union, suppress Insurrections and repel Invasions;
+
+To provide for organizing, arming, and disciplining, the Militia, and for governing such Part of them as may be employed in the Service of the United States, reserving to the States respectively, the Appointment of the Officers, and the Authority of training the Militia according to the discipline prescribed by Congress;
+
+To exercise exclusive Legislation in all Cases whatsoever, over such District (not exceeding ten Miles square) as may, by Cession of particular States, and the Acceptance of Congress, become the Seat of the Government of the United States, and to exercise like Authority over all Places purchased by the Consent of the Legislature of the State in which the Same shall be, for the Erection of Forts, Magazines, Arsenals, dock-Yards and other needful Buildings;-And
+
+To make all Laws which shall be necessary and proper for carrying into Execution the foregoing Powers, and all other Powers vested by this Constitution in the Government of the United States, or in any Department or Officer thereof.
+
+##### Section 9: Powers Denied Congress
+
+The Migration or Importation of such Persons as any of the States now existing shall think proper to admit, shall not be prohibited by the Congress prior to the Year one thousand eight hundred and eight, but a Tax or duty may be imposed on such Importation, not exceeding ten dollars for each Person.
+
+The Privilege of the Writ of Habeas Corpus shall not be suspended, unless when in Cases of Rebellion or Invasion the public Safety may require it.
+
+No Bill of Attainder or ex post facto Law shall be passed.
+
+No Capitation, or other direct, Tax shall be laid, unless in Proportion to the Census or enumeration herein before directed to be taken.
+
+No Tax or Duty shall be laid on Articles exported from any State.
+
+No Preference shall be given by any Regulation of Commerce or Revenue to the Ports of one State over those of another: nor shall Vessels bound to, or from, one State, be obliged to enter, clear, or pay Duties in another.
+
+No Money shall be drawn from the Treasury, but in Consequence of Appropriations made by Law; and a regular Statement and Account of the Receipts and Expenditures of all public Money shall be published from time to time.
+
+No Title of Nobility shall be granted by the United States: And no Person holding any Office of Profit or Trust under them, shall, without the Consent of the Congress, accept of any present, Emolument, Office, or Title, of any kind whatever, from any King, Prince, or foreign State.
+
+##### Section 10: Powers Denied to the States
+
+No State shall enter into any Treaty, Alliance, or Confederation; grant Letters of Marque and Reprisal; coin Money; emit Bills of Credit; make any Thing but gold and silver Coin a Tender in Payment of Debts; pass any Bill of Attainder, ex post facto Law, or Law impairing the Obligation of Contracts, or grant any Title of Nobility.
+
+No State shall, without the Consent of the Congress, lay any Imposts or Duties on Imports or Exports, except what may be absolutely necessary for executing it's inspection Laws: and the net Produce of all Duties and Imposts, laid by any State on Imports or Exports, shall be for the Use of the Treasury of the United States; and all such Laws shall be subject to the Revision and Controul of the Congress.
+
+No State shall, without the Consent of Congress, lay any Duty of Tonnage, keep Troops, or Ships of War in time of Peace, enter into any Agreement or Compact with another State, or with a foreign Power, or engage in War, unless actually invaded, or in such imminent Danger as will not admit of delay.
+
+---
+
+## Article II
+
+##### Section 1
+
+The executive Power shall be vested in a President of the United States of America.
+
+He shall hold his Office during the Term of four Years, and, together with the Vice President, chosen for the same Term, be elected, as follows:
+
+Each State shall appoint, in such Manner as the Legislature thereof may direct, a Number of Electors, equal to the whole Number of Senators and Representatives to which the State may be entitled in the Congress: but no Senator or Representative, or Person holding an Office of Trust or Profit under the United States, shall be appointed an Elector.
+
+The Electors shall meet in their respective States, and vote by Ballot for two Persons, of whom one at least shall not be an Inhabitant of the same State with themselves. And they shall make a List of all the Persons voted for, and of the Number of Votes for each; which List they shall sign and certify, and transmit sealed to the Seat of the Government of the United States, directed to the President of the Senate. The President of the Senate shall, in the Presence of the Senate and House of Representatives, open all the Certificates, and the Votes shall then be counted. The Person having the greatest Number of Votes shall be the President, if such Number be a Majority of the whole Number of Electors appointed; and if there be more than one who have such Majority, and have an equal Number of Votes, then the House of Representatives shall immediately chuse by Ballot one of them for President; and if no Person have a Majority, then from the five highest on the List the said House shall in like Manner chuse the President. But in chusing the President, the Votes shall be taken by States, the Representation from each State having one Vote; A quorum for this Purpose shall consist of a Member or Members from two thirds of the States, and a Majority of all the States shall be necessary to a Choice. In every Case, after the Choice of the President, the Person having the greatest Number of Votes of the Electors shall be the Vice President. But if there should remain two or more who have equal Votes, the Senate shall chuse from them by Ballot the Vice President.
+
+The Congress may determine the Time of chusing the Electors, and the Day on which they shall give their Votes; which Day shall be the same throughout the United States.
+
+No Person except a natural born Citizen, or a Citizen of the United States, at the time of the Adoption of this Constitution, shall be eligible to the Office of President; neither shall any Person be eligible to that Office who shall not have attained to the Age of thirty five Years, and been fourteen Years a Resident within the United States.
+
+In Case of the Removal of the President from Office, or of his Death, Resignation, or Inability to discharge the Powers and Duties of the said Office, the Same shall devolve on the Vice President, and the Congress may by Law provide for the Case of Removal, Death, Resignation or Inability, both of the President and Vice President, declaring what Officer shall then act as President, and such Officer shall act accordingly, until the Disability be removed, or a President shall be elected.
+
+The President shall, at stated Times, receive for his Services, a Compensation, which shall neither be encreased nor diminished during the Period for which he shall have been elected, and he shall not receive within that Period any other Emolument from the United States, or any of them.
+
+Before he enter on the Execution of his Office, he shall take the following Oath or Affirmation:--"I do solemnly swear (or affirm) that I will faithfully execute the Office of President of the United States, and will to the best of my Ability, preserve, protect and defend the Constitution of the United States."
+
+##### Section 2
+
+The President shall be Commander in Chief of the Army and Navy of the United States, and of the Militia of the several States, when called into the actual Service of the United States; he may require the Opinion, in writing, of the principal Officer in each of the executive Departments, upon any Subject relating to the Duties of their respective Offices, and he shall have Power to grant Reprieves and Pardons for Offences against the United States, except in Cases of Impeachment.
+
+He shall have Power, by and with the Advice and Consent of the Senate, to make Treaties, provided two thirds of the Senators present concur; and he shall nominate, and by and with the Advice and Consent of the Senate, shall appoint Ambassadors, other public Ministers and Consuls, Judges of the supreme Court, and all other Officers of the United States, whose Appointments are not herein otherwise provided for, and which shall be established by Law: but the Congress may by Law vest the Appointment of such inferior Officers, as they think proper, in the President alone, in the Courts of Law, or in the Heads of Departments.
+
+The President shall have Power to fill up all Vacancies that may happen during the Recess of the Senate, by granting Commissions which shall expire at the End of their next Session.
+
+##### Section 3
+
+He shall from time to time give to the Congress Information of the State of the Union, and recommend to their Consideration such Measures as he shall judge necessary and expedient; he may, on extraordinary Occasions, convene both Houses, or either of them, and in Case of Disagreement between them, with Respect to the Time of Adjournment, he may adjourn them to such Time as he shall think proper; he shall receive Ambassadors and other public Ministers; he shall take Care that the Laws be faithfully executed, and shall Commission all the Officers of the United States.
+
+##### Section 4
+
+The President, Vice President and all civil Officers of the United States, shall be removed from Office on Impeachment for, and Conviction of, Treason, Bribery, or other high Crimes and Misdemeanors.
+
+---
+
+## Article III
+
+##### Section 1
+
+The judicial Power of the United States, shall be vested in one supreme Court, and in such inferior Courts as the Congress may from time to time ordain and establish. The Judges, both of the supreme and inferior Courts, shall hold their Offices during good Behaviour, and shall, at stated Times, receive for their Services, a Compensation, which shall not be diminished during their Continuance in Office.
+
+##### Section 2
+
+The judicial Power shall extend to all Cases, in Law and Equity, arising under this Constitution, the Laws of the United States, and Treaties made, or which shall be made, under their Authority;--to all Cases affecting Ambassadors, other public Ministers and Consuls;--to all Cases of admiralty and maritime Jurisdiction;--to Controversies to which the United States shall be a Party;-- to Controversies between two or more States;--between a State and Citizens of another State;--between Citizens of different States;--between Citizens of the same State claiming Lands under Grants of different States, and between a State, or the Citizens thereof, and foreign States, Citizens or Subjects.
+
+In all Cases affecting Ambassadors, other public Ministers and Consuls, and those in which a State shall be Party, the supreme Court shall have original Jurisdiction. In all the other Cases before mentioned, the supreme Court shall have appellate Jurisdiction, both as to Law and Fact, with such Exceptions, and under such Regulations as the Congress shall make.
+
+The Trial of all Crimes, except in Cases of Impeachment; shall be by Jury; and such Trial shall be held in the State where the said Crimes shall have been committed; but when not committed within any State, the Trial shall be at such Place or Places as the Congress may by Law have directed.
+
+##### Section 3
+
+Treason against the United States, shall consist only in levying War against them, or in adhering to their Enemies, giving them Aid and Comfort. No Person shall be convicted of Treason unless on the Testimony of two Witnesses to the same overt Act, or on Confession in open Court.
+
+The Congress shall have Power to declare the Punishment of Treason, but no Attainder of Treason shall work Corruption of Blood, or Forfeiture except during the Life of the Person attainted.
+
+---
+
+## Article IV
+
+##### Section 1
+
+Full Faith and Credit shall be given in each State to the public Acts, Records, and judicial Proceedings of every other State. And the Congress may by general Laws prescribe the Manner in which such Acts, Records and Proceedings shall be proved, and the Effect thereof.
+
+##### Section 2
+
+The Citizens of each State shall be entitled to all Privileges and Immunities of Citizens in the several States.
+
+A Person charged in any State with Treason, Felony, or other Crime, who shall flee from Justice, and be found in another State, shall on Demand of the executive Authority of the State from which he fled, be delivered up, to be removed to the State having Jurisdiction of the Crime.
+
+No Person held to Service or Labour in one State, under the Laws thereof, escaping into another, shall, in Consequence of any Law or Regulation therein, be discharged from such Service or Labour, but shall be delivered up on Claim of the Party to whom such Service or Labour may be due.
+
+##### Section 3
+
+New States may be admitted by the Congress into this Union; but no new State shall be formed or erected within the Jurisdiction of any other State; nor any State be formed by the Junction of two or more States, or Parts of States, without the Consent of the Legislatures of the States concerned as well as of the Congress.
+
+The Congress shall have Power to dispose of and make all needful Rules and Regulations respecting the Territory or other Property belonging to the United States; and nothing in this Constitution shall be so construed as to Prejudice any Claims of the United States, or of any particular State.
+
+##### Section 4
+
+The United States shall guarantee to every State in this Union a Republican Form of Government, and shall protect each of them against Invasion; and on Application of the Legislature, or of the Executive (when the Legislature cannot be convened) against domestic Violence.
+
+---
+
+## Article V
+
+The Congress, whenever two thirds of both Houses shall deem it necessary, shall propose Amendments to this Constitution, or, on the Application of the Legislatures of two thirds of the several States, shall call a Convention for proposing Amendments, which, in either Case, shall be valid to all Intents and Purposes, as Part of this Constitution, when ratified by the Legislatures of three fourths of the several States, or by Conventions in three fourths thereof, as the one or the other Mode of Ratification may be proposed by the Congress; Provided that no Amendment which may be made prior to the Year One thousand eight hundred and eight shall in any Manner affect the first and fourth Clauses in the Ninth Section of the first Article; and that no State, without its Consent, shall be deprived of its equal Suffrage in the Senate.
+
+---
+
+## Article VI
+
+All Debts contracted and Engagements entered into, before the Adoption of this Constitution, shall be as valid against the United States under this Constitution, as under the Confederation.
+
+This Constitution, and the Laws of the United States which shall be made in Pursuance thereof; and all Treaties made, or which shall be made, under the Authority of the United States, shall be the supreme Law of the Land; and the Judges in every State shall be bound thereby, any Thing in the Constitution or Laws of any State to the Contrary notwithstanding.
+
+The Senators and Representatives before mentioned, and the Members of the several State Legislatures, and all executive and judicial Officers, both of the United States and of the several States, shall be bound by Oath or Affirmation, to support this Constitution; but no religious Test shall ever be required as a Qualification to any Office or public Trust under the United States.
+
+---
+
+## Article VII
+
+The Ratification of the Conventions of nine States, shall be sufficient for the Establishment of this Constitution between the States so ratifying the Same.
+
+---
+
+## First Amendment
+
+Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+
+---
+
+## Second Amendment
+
+A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+
+---
+
+## Third Amendment
+
+No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+
+---
+
+## Fourth Amendment
+
+The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
+
+---
+
+## Fifth Amendment
+
+No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
+
+---
+
+## Sixth Amendment
+
+In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.
+
+---
+
+## Seventh Amendment
+
+In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved, and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.
+
+---
+
+## Eighth Amendment
+
+Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.
+
+---
+
+## Ninth Amendment
+
+The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.
+
+---
+
+## 10th Amendment
+
+The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people.
+
+---
+
+## 11th Amendment
+
+The Judicial power of the United States shall not be construed to extend to any suit in law or equity, commenced or prosecuted against one of the United States by Citizens of another State, or by Citizens or Subjects of any Foreign State.
+
+---
+
+## 12th Amendment
+
+The Electors shall meet in their respective states and vote by ballot for President and Vice-President, one of whom, at least, shall not be an inhabitant of the same state with themselves; they shall name in their ballots the person voted for as President, and in distinct ballots the person voted for as Vice-President, and they shall make distinct lists of all persons voted for as President, and of all persons voted for as Vice-President, and of the number of votes for each, which lists they shall sign and certify, and transmit sealed to the seat of the government of the United States, directed to the President of the Senate; -- the President of the Senate shall, in the presence of the Senate and House of Representatives, open all the certificates and the votes shall then be counted; -- The person having the greatest number of votes for President, shall be the President, if such number be a majority of the whole number of Electors appointed; and if no person have such majority, then from the persons having the highest numbers not exceeding three on the list of those voted for as President, the House of Representatives shall choose immediately, by ballot, the President. But in choosing the President, the votes shall be taken by states, the representation from each state having one vote; a quorum for this purpose shall consist of a member or members from two-thirds of the states, and a majority of all the states shall be necessary to a choice. And if the House of Representatives shall not choose a President whenever the right of choice shall devolve upon them, before the fourth day of March next following, then the Vice-President shall act as President, as in the case of the death or other constitutional disability of the President.\-- The person having the greatest number of votes as Vice-President, shall be the Vice-President, if such number be a majority of the whole number of Electors appointed, and if no person have a majority, then from the two highest numbers on the list, the Senate shall choose the Vice-President; a quorum for the purpose shall consist of two-thirds of the whole number of Senators, and a majority of the whole number shall be necessary to a choice. But no person constitutionally ineligible to the office of President shall be eligible to that of Vice-President of the United States.
+
+---
+
+## 13th Amendment
+
+##### Section 1
+
+Neither slavery nor involuntary servitude, except as a punishment for crime whereof the party shall have been duly convicted, shall exist within the United States, or any place subject to their jurisdiction.
+
+##### Section 2
+
+Congress shall have power to enforce this article by appropriate legislation.
+
+---
+
+## 14th Amendment
+
+##### Section 1
+
+All persons born or naturalized in the United States, and subject to the jurisdiction thereof, are citizens of the United States and of the State wherein they reside. No State shall make or enforce any law which shall abridge the privileges or immunities of citizens of the United States; nor shall any State deprive any person of life, liberty, or property, without due process of law; nor deny to any person within its jurisdiction the equal protection of the laws.
+
+##### Section 2
+
+Representatives shall be apportioned among the several States according to their respective numbers, counting the whole number of persons in each State, excluding Indians not taxed. But when the right to vote at any election for the choice of electors for President and Vice-President of the United States, Representatives in Congress, the Executive and Judicial officers of a State, or the members of the Legislature thereof, is denied to any of the male inhabitants of such State, being twenty-one years of age, and citizens of the United States, or in any way abridged, except for participation in rebellion, or other crime, the basis of representation therein shall be reduced in the proportion which the number of such male citizens shall bear to the whole number of male citizens twenty-one years of age in such State.
+
+##### Section 3
+
+No person shall be a Senator or Representative in Congress, or elector of President and Vice-President, or hold any office, civil or military, under the United States, or under any State, who, having previously taken an oath, as a member of Congress, or as an officer of the United States, or as a member of any State legislature, or as an executive or judicial officer of any State, to support the Constitution of the United States, shall have engaged in insurrection or rebellion against the same, or given aid or comfort to the enemies thereof. But Congress may by a vote of two-thirds of each House, remove such disability.
+
+##### Section 4
+
+The validity of the public debt of the United States, authorized by law, including debts incurred for payment of pensions and bounties for services in suppressing insurrection or rebellion, shall not be questioned. But neither the United States nor any State shall assume or pay any debt or obligation incurred in aid of insurrection or rebellion against the United States, or any claim for the loss or emancipation of any slave; but all such debts, obligations and claims shall be held illegal and void.
+
+##### Section 5
+
+The Congress shall have power to enforce, by appropriate legislation, the provisions of this article.
+
+---
+
+## 15th Amendment
+
+##### Section 1
+
+The right of citizens of the United States to vote shall not be denied or abridged by the United States or by any State on account of race, color, or previous condition of servitude.
+
+##### Section 2
+
+The Congress shall have power to enforce this article by appropriate legislation.
+
+---
+
+## 16th Amendment
+
+The Congress shall have power to lay and collect taxes on incomes, from whatever source derived, without apportionment among the several States, and without regard to any census or enumeration.
+
+---
+
+## 17th Amendment
+
+The Senate of the United States shall be composed of two Senators from each State, elected by the people thereof, for six years; and each Senator shall have one vote. The electors in each State shall have the qualifications requisite for electors of the most numerous branch of the State legislatures.
+
+When vacancies happen in the representation of any State in the Senate, the executive authority of such State shall issue writs of election to fill such vacancies: Provided, That the legislature of any State may empower the executive thereof to make temporary appointments until the people fill the vacancies by election as the legislature may direct.
+
+This amendment shall not be so construed as to affect the election or term of any Senator chosen before it becomes valid as part of the Constitution.
+
+---
+
+## 18th Amendment
+
+##### Section 1
+
+After one year from the ratification of this article the manufacture, sale, or transportation of intoxicating liquors within, the importation thereof into, or the exportation thereof from the United States and all territory subject to the jurisdiction thereof for beverage purposes is hereby prohibited.
+
+##### Section 2
+
+The Congress and the several States shall have concurrent power to enforce this article by appropriate legislation.
+
+##### Section 3
+
+[This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by the legislatures of the several States, as provided in the Constitution, within seven years from the date of the submission hereof to the States by the Congress.](https://constitutioncenter.org/the-constitution/amendments/amendment-xxi)
+
+---
+
+## 19th Amendment
+
+The right of citizens of the United States to vote shall not be denied or abridged by the United States or by any State on account of sex.
+
+Congress shall have power to enforce this article by appropriate legislation.
+
+---
+
+## 20th Amendment
+
+##### Section 1
+
+The terms of the President and the Vice President shall end at noon on the 20th day of January, and the terms of Senators and Representatives at noon on the 3d day of January, of the years in which such terms would have ended if this article had not been ratified; and the terms of their successors shall then begin.
+
+##### Section 2
+
+The Congress shall assemble at least once in every year, and such meeting shall begin at noon on the 3d day of January, unless they shall by law appoint a different day.
+
+##### Section 3
+
+If, at the time fixed for the beginning of the term of the President, the President elect shall have died, the Vice President elect shall become President. If a President shall not have been chosen before the time fixed for the beginning of his term, or if the President elect shall have failed to qualify, then the Vice President elect shall act as President until a President shall have qualified; and the Congress may by law provide for the case wherein neither a President elect nor a Vice President elect shall have qualified, declaring who shall then act as President, or the manner in which one who is to act shall be selected, and such person shall act accordingly until a President or Vice President shall have qualified.
+
+##### Section 4
+
+The Congress may by law provide for the case of the death of any of the persons from whom the House of Representatives may choose a President whenever the right of choice shall have devolved upon them, and for the case of the death of any of the persons from whom the Senate may choose a Vice President whenever the right of choice shall have devolved upon them.
+
+##### Section 5
+
+Sections 1 and 2 shall take effect on the 15th day of October following the ratification of this article.
+
+##### Section 6
+
+This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by the legislatures of three-fourths of the several States within seven years from the date of its submission.
+
+---
+
+## 21st Amendment
+
+##### Section 1
+
+The eighteenth article of amendment to the Constitution of the United States is hereby repealed.
+
+##### Section 2
+
+The transportation or importation into any State, Territory, or possession of the United States for delivery or use therein of intoxicating liquors, in violation of the laws thereof, is hereby prohibited.
+
+##### Section 3
+
+This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by conventions in the several States, as provided in the Constitution, within seven years from the date of the submission hereof to the States by the Congress.
+
+---
+
+## 22nd Amendment
+
+##### Section 1
+
+No person shall be elected to the office of the President more than twice, and no person who has held the office of President, or acted as President, for more than two years of a term to which some other person was elected President shall be elected to the office of the President more than once. But this Article shall not apply to any person holding the office of President when this Article was proposed by the Congress, and shall not prevent any person who may be holding the office of President, or acting as President, during the term within which this Article becomes operative from holding the office of President or acting as President during the remainder of such term.
+
+##### Section 2
+
+This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by the legislatures of three-fourths of the several States within seven years from the date of its submission to the States by the Congress.
+
+---
+
+## 23rd Amendment
+
+##### Section 1
+
+The District constituting the seat of Government of the United States shall appoint in such manner as Congress may direct:
+
+A number of electors of President and Vice President equal to the whole number of Senators and Representatives in Congress to which the District would be entitled if it were a State, but in no event more than the least populous State; they shall be in addition to those appointed by the States, but they shall be considered, for the purposes of the election of President and Vice President, to be electors appointed by a State; and they shall meet in the District and perform such duties as provided by the twelfth article of amendment.
+
+##### Section 2
+
+The Congress shall have power to enforce this article by appropriate legislation.
+
+---
+
+## 24th Amendment
+
+##### Section 1
+
+The right of citizens of the United States to vote in any primary or other election for President or Vice President, for electors for President or Vice President, or for Senator or Representative in Congress, shall not be denied or abridged by the United States or any State by reason of failure to pay poll tax or other tax.
+
+##### Section 2
+
+The Congress shall have power to enforce this article by appropriate legislation.
+
+---
+
+## 25th Amendment
+
+##### Section 1
+
+In case of the removal of the President from office or of his death or resignation, the Vice President shall become President.
+
+##### Section 2
+
+Whenever there is a vacancy in the office of the Vice President, the President shall nominate a Vice President who shall take office upon confirmation by a majority vote of both Houses of Congress.
+
+##### Section 3
+
+Whenever the President transmits to the President pro tempore of the Senate and the Speaker of the House of Representatives his written declaration that he is unable to discharge the powers and duties of his office, and until he transmits to them a written declaration to the contrary, such powers and duties shall be discharged by the Vice President as Acting President.
+
+##### Section 4
+
+Whenever the Vice President and a majority of either the principal officers of the executive departments or of such other body as Congress may by law provide, transmit to the President pro tempore of the Senate and the Speaker of the House of Representatives their written declaration that the President is unable to discharge the powers and duties of his office, the Vice President shall immediately assume the powers and duties of the office as Acting President.
+
+Thereafter, when the President transmits to the President pro tempore of the Senate and the Speaker of the House of Representatives his written declaration that no inability exists, he shall resume the powers and duties of his office unless the Vice President and a majority of either the principal officers of the executive department or of such other body as Congress may by law provide, transmit within four days to the President pro tempore of the Senate and the Speaker of the House of Representatives their written declaration that the President is unable to discharge the powers and duties of his office. Thereupon Congress shall decide the issue, assembling within forty-eight hours for that purpose if not in session. If the Congress, within twenty-one days after receipt of the latter written declaration, or, if Congress is not in session, within twenty-one days after Congress is required to assemble, determines by two-thirds vote of both Houses that the President is unable to discharge the powers and duties of his office, the Vice President shall continue to discharge the same as Acting President; otherwise, the President shall resume the powers and duties of his office.
+
+---
+
+## 26th Amendment
+
+##### Section 1
+
+The right of citizens of the United States, who are eighteen years of age or older, to vote shall not be denied or abridged by the United States or by any State on account of age.
+
+##### Section 2
+
+The Congress shall have power to enforce this article by appropriate legislation.
+
+---
+
+## 27th Amendment
+
+No law, varying the compensation for the services of the Senators and Representatives, shall take effect, until an election of Representatives shall have intervened.
+
+---

--- a/test-data/Full_Text_of_the_U.S._Constitutional_amendments.md
+++ b/test-data/Full_Text_of_the_U.S._Constitutional_amendments.md
@@ -1,0 +1,251 @@
+---
+title: "All Amendments to the United States Constitution"
+source: "https://hrlibrary.umn.edu/education/all_amendments_usconst.htm"
+author:
+published:
+created: 2026-04-08
+description:
+tags:
+  - "clippings"
+---
+
+**All Amendments to the United States Constitution**
+
+[Amendments 1-10](https://hrlibrary.umn.edu/education/all_amendments_usconst.htm#Amendments1-10) | [Amendments 11-27](https://hrlibrary.umn.edu/education/all_amendments_usconst.htm#Amendments11-27)
+
+---
+
+Congress of the United States  
+begun and held at the City of New-York, on  
+Wednesday the fourth of March, one thousand seven hundred and eighty nine.
+
+**THE** Conventions of a number of the States, having at the time of their adopting the Constitution, expressed a desire, in order to prevent misconstruction or abuse of its powers, that further declaratory and restrictive clauses should be added: And as extending the ground of public confidence in the Government, will best ensure the beneficent ends of its institution.
+
+**RESOLVED** by the Senate and House of Representatives of the United States of America, in Congress assembled, two thirds of both Houses concurring, that the following Articles be proposed to the Legislatures of the several States, as amendments to the Constitution of the United States, all, or any of which Articles, when ratified by three fourths of the said Legislatures, to be valid to all intents and purposes, as part of the said Constitution; viz.
+
+**ARTICLES** in addition to, and Amendment of the Constitution of the United States of America, proposed by Congress, and ratified by the Legislatures of the several States, pursuant to the fifth Article of the original Constitution.
+
+> _Note: The following text is a transcription of the first ten amendments to the Constitution in their original form. These amendments were ratified December 15, 1791, and form what is known as the "Bill of Rights."_
+
+**AMENDMENT I**
+
+Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+
+**AMENDMENT II**
+
+A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+
+**AMENDMENT III**
+
+No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+
+**AMENDMENT IV**
+
+The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
+
+**AMENDMENT V**
+
+No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
+
+**AMENDMENT VI**
+
+In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.
+
+**AMENDMENT VII**
+
+In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved, and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.
+
+**AMENDMENT VIII**
+
+Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.
+
+**AMENDMENT IX**
+
+The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.
+
+**AMENDMENT X**
+
+The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people.
+
+---
+
+**AMENDMENT XI -** Passed by Congress March 4, 1794. Ratified February 7, 1795.
+
+> _Note: Article III, section 2, of the Constitution was modified by amendment 11._
+
+The Judicial power of the United States shall not be construed to extend to any suit in law or equity, commenced or prosecuted against one of the United States by Citizens of another State, or by Citizens or Subjects of any Foreign State.
+
+**AMENDMENT XII -** Passed by Congress December 9, 1803. Ratified June 15, 1804.
+
+> _Note: A portion of Article II, section 1 of the Constitution was superseded by the 12th amendment._
+
+The Electors shall meet in their respective states and vote by ballot for President and Vice-President, one of whom, at least, shall not be an inhabitant of the same state with themselves; they shall name in their ballots the person voted for as President, and in distinct ballots the person voted for as Vice-President, and they shall make distinct lists of all persons voted for as President, and of all persons voted for as Vice-President, and of the number of votes for each, which lists they shall sign and certify, and transmit sealed to the seat of the government of the United States, directed to the President of the Senate; -- the President of the Senate shall, in the presence of the Senate and House of Representatives, open all the certificates and the votes shall then be counted; -- The person having the greatest number of votes for President, shall be the President, if such number be a majority of the whole number of Electors appointed; and if no person have such majority, then from the persons having the highest numbers not exceeding three on the list of those voted for as President, the House of Representatives shall choose immediately, by ballot, the President. But in choosing the President, the votes shall be taken by states, the representation from each state having one vote; a quorum for this purpose shall consist of a member or members from two-thirds of the states, and a majority of all the states shall be necessary to a choice. \[And if the House of Representatives shall not choose a President whenever the right of choice shall devolve upon them, before the fourth day of March next following, then the Vice-President shall act as President, as in case of the death or other constitutional disability of the President. --\]\* The person having the greatest number of votes as Vice-President, shall be the Vice-President, if such number be a majority of the whole number of Electors appointed, and if no person have a majority, then from the two highest numbers on the list, the Senate shall choose the Vice-President; a quorum for the purpose shall consist of two-thirds of the whole number of Senators, and a majority of the whole number shall be necessary to a choice. But no person constitutionally ineligible to the office of President shall be eligible to that of Vice-President of the United States.
+
+> _\*Superseded by section 3 of the 20th amendment._
+
+**AMENDMENT XIII -** Passed by Congress January 31, 1865. Ratified December 6, 1865.
+
+> _Note: A portion of Article IV, section 2, of the Constitution was superseded by the 13th amendment._
+
+Section 1.  
+Neither slavery nor involuntary servitude, except as a punishment for crime whereof the party shall have been duly convicted, shall exist within the United States, or any place subject to their jurisdiction.
+
+Section 2.  
+Congress shall have power to enforce this article by appropriate legislation.
+
+**AMENDMENT XIV -** Passed by Congress June 13, 1866. Ratified July 9, 1868.
+
+> _Note: Article I, section 2, of the Constitution was modified by section 2 of the 14th amendment._
+
+Section 1.  
+All persons born or naturalized in the United States, and subject to the jurisdiction thereof, are citizens of the United States and of the State wherein they reside. No State shall make or enforce any law which shall abridge the privileges or immunities of citizens of the United States; nor shall any State deprive any person of life, liberty, or property, without due process of law; nor deny to any person within its jurisdiction the equal protection of the laws.
+
+Section 2.  
+Representatives shall be apportioned among the several States according to their respective numbers, counting the whole number of persons in each State, excluding Indians not taxed. But when the right to vote at any election for the choice of electors for President and Vice-President of the United States, Representatives in Congress, the Executive and Judicial officers of a State, or the members of the Legislature thereof, is denied to any of the male inhabitants of such State, being twenty-one years of age,\* and citizens of the United States, or in any way abridged, except for participation in rebellion, or other crime, the basis of representation therein shall be reduced in the proportion which the number of such male citizens shall bear to the whole number of male citizens twenty-one years of age in such State.
+
+Section 3.  
+No person shall be a Senator or Representative in Congress, or elector of President and Vice-President, or hold any office, civil or military, under the United States, or under any State, who, having previously taken an oath, as a member of Congress, or as an officer of the United States, or as a member of any State legislature, or as an executive or judicial officer of any State, to support the Constitution of the United States, shall have engaged in insurrection or rebellion against the same, or given aid or comfort to the enemies thereof. But Congress may by a vote of two-thirds of each House, remove such disability.
+
+Section 4.  
+The validity of the public debt of the United States, authorized by law, including debts incurred for payment of pensions and bounties for services in suppressing insurrection or rebellion, shall not be questioned. But neither the United States nor any State shall assume or pay any debt or obligation incurred in aid of insurrection or rebellion against the United States, or any claim for the loss or emancipation of any slave; but all such debts, obligations and claims shall be held illegal and void.
+
+Section 5.  
+The Congress shall have the power to enforce, by appropriate legislation, the provisions of this article.
+
+> _\*Changed by section 1 of the 26th amendment._
+
+**AMENDMENT XV -** Passed by Congress February 26, 1869. Ratified February 3, 1870.
+
+Section 1.  
+The right of citizens of the United States to vote shall not be denied or abridged by the United States or by any State on account of race, color, or previous condition of servitude--
+
+Section 2.  
+The Congress shall have the power to enforce this article by appropriate legislation.
+
+**AMENDMENT XVI -** Passed by Congress July 2, 1909. Ratified February 3, 1913.
+
+> _Note: Article I, section 9, of the Constitution was modified by amendment 16._
+
+The Congress shall have power to lay and collect taxes on incomes, from whatever source derived, without apportionment among the several States, and without regard to any census or enumeration.
+
+**AMENDMENT XVII -** Passed by Congress May 13, 1912. Ratified April 8, 1913.
+
+> _Note: Article I, section 3, of the Constitution was modified by the 17th amendment._
+
+The Senate of the United States shall be composed of two Senators from each State, elected by the people thereof, for six years; and each Senator shall have one vote. The electors in each State shall have the qualifications requisite for electors of the most numerous branch of the State legislatures.
+
+When vacancies happen in the representation of any State in the Senate, the executive authority of such State shall issue writs of election to fill such vacancies: Provided, That the legislature of any State may empower the executive thereof to make temporary appointments until the people fill the vacancies by election as the legislature may direct.
+
+This amendment shall not be so construed as to affect the election or term of any Senator chosen before it becomes valid as part of the Constitution.
+
+**AMENDMENT XVIII -** Passed by Congress December 18, 1917. Ratified January 16, 1919. Repealed by amendment 21.
+
+Section 1.  
+After one year from the ratification of this article the manufacture, sale, or transportation of intoxicating liquors within, the importation thereof into, or the exportation thereof from the United States and all territory subject to the jurisdiction thereof for beverage purposes is hereby prohibited.
+
+Section 2.  
+The Congress and the several States shall have concurrent power to enforce this article by appropriate legislation.
+
+Section 3.  
+This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by the legislatures of the several States, as provided in the Constitution, within seven years from the date of the submission hereof to the States by the Congress.
+
+**AMENDMENT XIX -** Passed by Congress June 4, 1919. Ratified August 18, 1920.
+
+The right of citizens of the United States to vote shall not be denied or abridged by the United States or by any State on account of sex.
+
+Congress shall have power to enforce this article by appropriate legislation.
+
+**AMENDMENT XX -** Passed by Congress March 2, 1932. Ratified January 23, 1933.
+
+> _Note: Article I, section 4, of the Constitution was modified by section 2 of this amendment. In addition, a portion of the 12th amendment was superseded by section 3._
+
+Section 1.  
+The terms of the President and the Vice President shall end at noon on the 20th day of January, and the terms of Senators and Representatives at noon on the 3d day of January, of the years in which such terms would have ended if this article had not been ratified; and the terms of their successors shall then begin.
+
+Section 2.  
+The Congress shall assemble at least once in every year, and such meeting shall begin at noon on the 3d day of January, unless they shall by law appoint a different day.
+
+Section 3.  
+If, at the time fixed for the beginning of the term of the President, the President elect shall have died, the Vice President elect shall become President. If a President shall not have been chosen before the time fixed for the beginning of his term, or if the President elect shall have failed to qualify, then the Vice President elect shall act as President until a President shall have qualified; and the Congress may by law provide for the case wherein neither a President elect nor a Vice President shall have qualified, declaring who shall then act as President, or the manner in which one who is to act shall be selected, and such person shall act accordingly until a President or Vice President shall have qualified.
+
+Section 4.  
+The Congress may by law provide for the case of the death of any of the persons from whom the House of Representatives may choose a President whenever the right of choice shall have devolved upon them, and for the case of the death of any of the persons from whom the Senate may choose a Vice President whenever the right of choice shall have devolved upon them.
+
+Section 5.  
+Sections 1 and 2 shall take effect on the 15th day of October following the ratification of this article.
+
+Section 6.  
+This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by the legislatures of three-fourths of the several States within seven years from the date of its submission.
+
+**AMENDMENT XXI -** Passed by Congress February 20, 1933. Ratified December 5, 1933.
+
+Section 1.  
+The eighteenth article of amendment to the Constitution of the United States is hereby repealed.
+
+Section 2.  
+The transportation or importation into any State, Territory, or Possession of the United States for delivery or use therein of intoxicating liquors, in violation of the laws thereof, is hereby prohibited.
+
+Section 3.  
+This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by conventions in the several States, as provided in the Constitution, within seven years from the date of the submission hereof to the States by the Congress.
+
+**AMENDMENT XXII -** Passed by Congress March 21, 1947. Ratified February 27, 1951.
+
+Section 1.  
+No person shall be elected to the office of the President more than twice, and no person who has held the office of President, or acted as President, for more than two years of a term to which some other person was elected President shall be elected to the office of President more than once. But this Article shall not apply to any person holding the office of President when this Article was proposed by Congress, and shall not prevent any person who may be holding the office of President, or acting as President, during the term within which this Article becomes operative from holding the office of President or acting as President during the remainder of such term.
+
+Section 2.  
+This article shall be inoperative unless it shall have been ratified as an amendment to the Constitution by the legislatures of three-fourths of the several States within seven years from the date of its submission to the States by the Congress.
+
+**AMENDMENT XXIII -** Passed by Congress June 16, 1960. Ratified March 29, 1961.
+
+Section 1.  
+The District constituting the seat of Government of the United States shall appoint in such manner as Congress may direct:
+
+A number of electors of President and Vice President equal to the whole number of Senators and Representatives in Congress to which the District would be entitled if it were a State, but in no event more than the least populous State; they shall be in addition to those appointed by the States, but they shall be considered, for the purposes of the election of President and Vice President, to be electors appointed by a State; and they shall meet in the District and perform such duties as provided by the twelfth article of amendment.
+
+Section 2.  
+The Congress shall have power to enforce this article by appropriate legislation.
+
+**AMENDMENT XXIV -** Passed by Congress August 27, 1962. Ratified January 23, 1964.
+
+Section 1.  
+The right of citizens of the United States to vote in any primary or other election for President or Vice President, for electors for President or Vice President, or for Senator or Representative in Congress, shall not be denied or abridged by the United States or any State by reason of failure to pay poll tax or other tax.
+
+Section 2.  
+The Congress shall have power to enforce this article by appropriate legislation.
+
+**AMENDMENT XXV -** Passed by Congress July 6, 1965. Ratified February 10, 1967.
+
+> _Note: Article II, section 1, of the Constitution was affected by the 25th amendment._
+
+Section 1.  
+In case of the removal of the President from office or of his death or resignation, the Vice President shall become President.
+
+Section 2.  
+Whenever there is a vacancy in the office of the Vice President, the President shall nominate a Vice President who shall take office upon confirmation by a majority vote of both Houses of Congress.
+
+Section 3.  
+Whenever the President transmits to the President pro tempore of the Senate and the Speaker of the House of Representatives his written declaration that he is unable to discharge the powers and duties of his office, and until he transmits to them a written declaration to the contrary, such powers and duties shall be discharged by the Vice President as Acting President.
+
+Section 4.  
+Whenever the Vice President and a majority of either the principal officers of the executive departments or of such other body as Congress may by law provide, transmit to the President pro tempore of the Senate and the Speaker of the House of Representatives their written declaration that the President is unable to discharge the powers and duties of his office, the Vice President shall immediately assume the powers and duties of the office as Acting President.
+
+Thereafter, when the President transmits to the President pro tempore of the Senate and the Speaker of the House of Representatives his written declaration that no inability exists, he shall resume the powers and duties of his office unless the Vice President and a majority of either the principal officers of the executive department or of such other body as Congress may by law provide, transmit within four days to the President pro tempore of the Senate and the Speaker of the House of Representatives their written declaration that the President is unable to discharge the powers and duties of his office. Thereupon Congress shall decide the issue, assembling within forty-eight hours for that purpose if not in session. If the Congress, within twenty-one days after receipt of the latter written declaration, or, if Congress is not in session, within twenty-one days after Congress is required to assemble, determines by two-thirds vote of both Houses that the President is unable to discharge the powers and duties of his office, the Vice President shall continue to discharge the same as Acting President; otherwise, the President shall resume the powers and duties of his office.
+
+**AMENDMENT XXVI -** Passed by Congress March 23, 1971. Ratified July 1, 1971.
+
+> _Note: Amendment 14, section 2, of the Constitution was modified by section 1 of the 26th amendment._
+
+Section 1.  
+The right of citizens of the United States, who are eighteen years of age or older, to vote shall not be denied or abridged by the United States or by any State on account of age.
+
+Section 2.  
+The Congress shall have power to enforce this article by appropriate legislation.
+
+**AMENDMENT XXVII** - Originally proposed Sept. 25, 1789. Ratified May 7, 1992.
+
+No law, varying the compensation for the services of the Senators and Representatives, shall take effect, until an election of representatives shall have intervened.
+
+---
+
+[Home](https://hrlibrary.umn.edu/index.html) || [Treaties](https://hrlibrary.umn.edu/treaties.htm) || [Search](https://hrlibrary.umn.edu/searchdevices.htm) || [Links](https://hrlibrary.umn.edu/links/links.htm)

--- a/test-data/Mexico_1917_rev_2015_Constitution_-_Constitute.md
+++ b/test-data/Mexico_1917_rev_2015_Constitution_-_Constitute.md
@@ -1,0 +1,2405 @@
+---
+title: "Mexico 1917 (rev. 2015) Constitution - Constitute"
+source: "https://www.constituteproject.org/constitution/Mexico_2015"
+author:
+  - "[[International law]]"
+published: 1856-06-24
+created: 2026-04-08
+description: "Mexico's Constitution of 1917 with Amendments through 2015"
+tags:
+  - "clippings"
+---
+## Mexico 1917 (rev. 2015) Subsequently amended
+
+Translated for the Comparative Constitutions Project by M. Fernanda Gomez Aban
+
+## TITLE ONE
+
+### CHAPTER I. Human Rights and Guarantees
+
+### Article 1
+
+In the United Mexican States, all individuals shall be entitled to the human rights granted by this Constitution and the international treaties signed by the Mexican State, as well as to the guarantees for the protection of these rights. Such human rights shall not be restricted or suspended, except for the cases and under the conditions established by this Constitution itself.
+
+The provisions relating to human rights shall be interpreted according to this Constitution and the international treaties on the subject, working in favor of the broader protection of people at all times.
+
+All authorities, in their areas of competence, are obliged to promote, respect, protect and guarantee Human Rights, in accordance with the principles of universality, interdependence, indivisibility and progressiveness. As a consequence, the State must prevent, investigate, penalize and rectify violations to Human Rights, according to the law.
+
+Slavery shall be forbidden in Mexico. Every individual who is considered as a slave at a foreign country shall be freed and protected under the law by just entering the country.
+
+Any form of discrimination, based on ethnic or national origin, gender, age, disabilities, social status, medical conditions, religion, opinions, sexual orientation, marital status, or any other form, which violates the human dignity or seeks to annul or diminish the rights and freedoms of the people, is prohibited.
+
+### Article 2
+
+The Mexican Nation is unique and indivisible.
+
+The nation is multicultural, based originally on its indigenous peoples, described as descendants of those inhabiting the country before colonization and that preserve their own social, economic, cultural and political institutions, or some of them.
+
+Consciousness of indigenous identity will be the fundamental criteria to determine to whom apply the provisions on indigenous people.
+
+An indigenous community is defined as the community that constitutes a cultural, economic and social unit settled in a territory and that recognizes its own authorities, according to their customs.
+
+Indigenous people’s right to self-determination shall be subjected to the Constitution in order to guarantee national unity. States’ and Federal District’s constitutions and laws must recognize indigenous peoples and communities, taking into account the general principles established in the previous paragraphs, as well as ethnic-linguistic and land settlement criteria.
+
+1. This Constitution recognizes and protects the indigenous peoples’ right to self-determination and, consequently, the right to autonomy, so that they can:
+	1. Decide their internal forms of coexistence, as well their social, economic, political and cultural organization.
+		2. Apply their own legal systems to regulate and solve their internal conflicts, subjected to the general principles of this Constitution, respecting the fundamental rights, the human rights and, above all, the dignity and safety of women. The law shall establish the way in which judges and courts will validate the aforementioned regulations.
+		3. Elect, in accordance with their traditional rules, procedures and customs, their authorities or representatives to exercise their own form of internal government, guaranteeing the right to vote and being voted of indigenous women and men under equitable condition; as well as to guarantee the access to public office or elected positions to those citizens that have been elected or designated within a framework that respects the federal pact and the sovereignty of the states. In no case the communitarian practices shall limit the electoral or political rights of the citizens in the election of their municipal authorities.
+		4. Preserve and enrich their languages, knowledge and all the elements that constitute their culture and identity.
+		5. Maintain and improve their environment and lands, according to this Constitution.
+		6. Attain with preferential use of the natural resources of the sites inhabited by their indigenous communities, except for the strategic resources defined by this Constitution. The foregoing rights shall be exercised respecting the forms of property ownership and land possession established in this Constitution and in the laws on the matter as well as respecting third parties’ rights. To achieve these goals, indigenous communities may form partnerships under the terms established by the Law.
+		7. Elect indigenous representatives for the town council in those municipalities with indigenous population.
+		The constitutions and laws of the States shall recognize and regulate these rights in the municipalities, with the purpose of strengthening indigenous peoples’ participation and political representation, in accordance with their traditions and regulations.
+		8. Have full access to State jurisdiction. In order to protect this right, in all trials and proceedings that involve natives, individually or collectively, their customs and cultural practices must be taken into account, respecting the provisions established in this Constitution. Indigenous people have, at all times, the right to be assisted by interpreters and counsels, who are familiar to their language and culture.
+	The constitutions and laws of the States and the Federal District shall establish those elements of self-determination and autonomy that may best express the conditions and aspirations of indigenous peoples in each State, as well as the rules, according to which indigenous communities will be defined as public interest entities.
+2. In order to promote equal opportunities for indigenous people and to eliminate discriminatory practices, the Federation, the Federal District, the States and the local councils shall establish the necessary institutions and policies to guarantee indigenous people’s rights and comprehensive development of indigenous communities. Such institutions and policies shall be designed and operated together with them.
+	In order to eliminate the scarcities and backwardness affecting indigenous towns and communities, authorities are obliged to:
+	1. Stimulate regional development in indigenous areas with the purpose of strengthening local economies and improving the quality of life. To achieve this goal, the three levels of government and the indigenous communities must take part in a coordinated manner. Local governments shall equitably determine the budget that is to be directly managed by the indigenous communities for specific goals.
+	2. Guarantee education and increase educational level of indigenous peoples, favoring bilingual and cross-cultural education, literacy, completion of the elementary and secondary education, technical training, high education and university education. Also, the authorities must establish a scholarship system for indigenous students at all grades, as well as define and carry out regional educational programs, according to indigenous peoples’ cultural heritage and opinion, and according to the law. Authorities must promote respect towards the several cultures of the Nation and knowledge about them.
+	3. Enforce an effective access to health services by increasing the coverage of the national health services, while making good use of traditional medicine and also to improve the indigenous people’s nutrition through food programs focusing especially on children.
+	4. Improve the living conditions of indigenous communities and the spaces used for social activities and recreation through policies that enables the access to public and private financing for housing construction and home improvements, as well as policies that extend the coverage of basic social services.
+	5. Promote indigenous women development by supporting their productive projects, protecting their health, granting incentives for their education and fostering indigenous women participation in decision-making process of their communities.
+	6. Extend the communication infrastructure, enabling integration of communities to the rest of the country, by constructing and expanding transportation routes and telecommunication means. Also, authorities are obliged to develop the conditions required so that indigenous peoples and communities may acquire, operate and manage media, in accordance with the law.
+	7. Support productive activities and sustainable development of indigenous communities through actions that allow them to achieve economic self-sufficiency; granting incentives for public and private investments that create new jobs; the use of new technology to increase productive capacity and to assure equitable access to supply and marketing systems.
+	8. Establish social policies to protect indigenous immigrants both, in Mexican territory and foreign countries, through actions that: assure farm workers’ labor rights, improve women’s health, provide special educational and nutrition programs for children and young people belonging to immigrant families, ensure their human rights are respected and spread indigenous peoples’ culture.
+	9. Consult indigenous peoples’ opinion and recommendations while preparing the National Development Plan, the State plans and the local plans and, if appropriate, incorporate their recommendations and proposals.
+	In order to enforce the obligations set forth herein, the House of Representatives, the legislative bodies of the Federal District and the States, as well as the Municipal Councils, within the scope of their jurisdictions, shall establish specific budgets to comply with these obligations, as well as the procedures enabling communities to participate in the exercise and supervision thereof.
+	Any community comparable to indigenous peoples shall have the same rights as the indigenous people, according to the law, without detrimental to rights of natives, their communities and peoples established in this Constitution.
+
+### Article 3
+
+All people have the right of education. The State – Federation, States, Federal District and Municipalities – will provide preschool, elementary, middle and high education. Preschool, elementary and middle educations are considered as basic education; these and the high school education will be mandatory.
+
+Education provided by the State shall develop harmoniously all human abilities and will stimulate in pupils the love for the country, respect for human rights and the principles of international solidarity, independence and justice.
+
+The State will guarantee the quality in mandatory education, in a way that educational material and methods, school organization, educational infrastructure and the suitability of teachers and principals ensure the highest learning achievement of students.
+
+1. According to the Article 24 regarding the freedom of religion, the education provided by the State shall be secular, therefore, state education shall be maintained entirely apart from any religious doctrine.
+2. The guiding principles for state education shall be based on scientific progress and shall fight against ignorance and its effects, servitude, fanaticism and prejudices.
+	Furthermore, state education shall:
+	1. Be democratic, understanding democracy not only as a legal structure and political regime, but also as a way of life grounded on the continuous economic, social and cultural development;
+	2. Be national, which means that, without hostility or exclusivism, state education shall cover national problems and the utilization of our resources, shall defend our political independence, assure our economic independence, and preserve and develop our culture;
+	3. Contribute to a better human coexistence, in order to strengthen the appreciation and respect for cultural diversity, human dignity, the integrity of the family, the convictions over society’s general interest, the fraternity and equality of rights ideals, avoiding privileges based on race, religion, group, sex or individual, and
+	4. It shall be of quality, based on the constant progress and highest academic achievement of the students;
+3. To fully comply with the provisions established in the second paragraph and under section II, the Federal Executive shall establish the syllabus for preschool, elementary and secondary education, as well as for teacher training colleges, to be applied throughout the country. To that end, the Federal Executive shall take into account the opinion of the States’ and the Federal District’s governments, as well as the opinions of civil society groups involved in education, teachers and parents, in accordance with the law. Additionally, admission to teaching positions and the promotions to management and supervisory positions in basic and medium education ran by the State shall be granted through competitive contest that shall guarantee that the knowledge and abilities are suitable for the post. The implementing law will set the criteria, terms and conditions of the mandatory evaluation for the admission, promotion, acknowledgment and continuance in the professional service with full respect to the constitutional rights of education workers. All admissions and promotions not granted according to law shall be deemed null and void. The provisions in this paragraph shall not be applicable to institutions referred to in section VII of this article;
+4. All the education provided by the State shall be free of charge;
+5. In addition to providing the preschool, elementary, middle and high education mentioned in previous paragraphs, the State will promote and use all educational types and modalities, from the starting education to the higher education, necessary for the development of the nation, will support scientific and technological research and will promote strengthening and spreading our culture;
+6. Private entities may provide all kinds of education. In accordance with the law, the State shall have powers to grant and cancel official accreditation to studies done at private institutions. In the case of pre-school, elementary and secondary education, as well as teacher training college, private schools must:
+	1. Provide education in accordance with the same purposes and criteria established in paragraph second and section II, as well as to comply with the syllabus mentioned in section III; and
+		2. Obtain a previous and explicit authorization from the authorities, under the terms provided by the Law.
+7. Universities and other higher education institutions, upon which the law has conferred autonomy, shall have both the powers and the duty to govern themselves. They must subject themselves to the principles established in this article to educate, do research and promote culture, respecting academic freedom, researching freedom, freedom to apply exams and to discuss ideas. These institutions shall develop their academic plans; they shall establish the terms for admission, promotion and tenure of their academic personnel; and they shall manage their estate. Labor relationships between institution and academic and administrative personnel shall be governed by section A of article 123 of this Constitution, in accordance with the terms of the National Labor Relations Act for a specially regulated work, without interfering with the autonomy, academic freedom, research freedom and the goals of the institutions referred herein,
+8. In order to unify and coordinate education throughout the country, the Congress of the Union shall issue the necessary laws to allocate the social duty of education among the Federation, the States and the Municipalities, and shall establish the pertinent budget and the penalties applicable to those civil servants who fail to comply or enforce these provisions, and to any other offender thereof, and
+9. In order to guarantee the provision of quality education services, the National Education Evaluation System has been created. The National Institute for the Evaluation of Education will coordinate said system. The National Institute for the Evaluation of Education will be an autonomous public agency, with legal personality and its own budget. The Institute shall evaluate the quality, performance and results of the national educational system in the preschool, elementary, junior high and high school. To that end, it shall:
+	1. Design and perform the evaluation measurements corresponding to components, processes or results of this system;
+		2. Issue the guidelines to which the federal and local educational authorities will be subject to, to perform the corresponding evaluation functions, and
+		3. Generate and publicize information, based on which it will issue the relevant guidelines to contribute to decisions about the improvement of education quality and its equity as an essential factor in the search of social equality.
+	The Governing Board will be the managing body of the Institute and will be formed with five members. The Federal Executive will present a list of three candidates for consideration of the House of Senators, which, with previous appearance of the proposed persons, shall appoint the person to fill the position. Appointment shall be decided with a two-thirds vote of the present members of the Senate or, during its recess, a two-thirds vote of the Permanent Commission, within a thirty days period not to be extended. Should the Senate fail to decide on the appointment within such time limit, the position will be filled by one of the three candidates to be selected by the Federal Executive.
+	In case that the Senate rejects the proposed list of three entirely, the Federal Executive shall submit a new one in accordance to the rules set forth in the previous paragraph. If the second list was rejected, the position will be filled by one of the candidates in the list to be selected by the Federal Executive.
+	Members of the Governing Board shall be capable and experienced individuals in the field under the purview of the Institute, and shall meet the requirements set forth by law. They shall remain in office for seven years in staggered terms, subject to only one reelection. Members of the Governing Board may not stay in office for more than fourteen years. In case of vacancy, the substitute will be appointed to complete the respective term. They can only be removed for severe cause under the terms of Title IV of this Constitution, and they shall not hold any other position job, position or commission with the exception of those in which they act in representation of Institute and those non-remunerated positions in teaching, scientific, cultural or charitable activities.
+	The Governing Board, in a collegiate manner shall appoint, by a 3-vote majority, the member that will preside for a term set by law.
+	The law shall establish the rules for the organization and operation of the Institute, which will govern its activities according to the principles of independence, transparency, objectivity, pertinence, diversity and inclusion.
+	The law shall establish the necessary mechanisms and actions to allow efficacious cooperation and coordination between the Institute and the federal and local education authorities to achieve a better discharge of their respective duties.
+
+### Article 4
+
+Man and woman are equal under the law. The law shall protect the organization and development of the family.
+
+Every person has the right to decide, in a free, responsible and informed manner, about the number of children desired and the timing between each of them.
+
+All individuals have the right to nutritional, sufficient and quality nourishment. The State shall guarantee this.
+
+Every person has the right to health protection. The law shall determine the bases and terms to access health services and shall establish the competence of the Federation and the Local Governments in regard to sanitation according to the item XVI in Article 73 of this Constitution.
+
+Any person has the right to a healthy environment for his/her own development and well-being. The State will guarantee the respect to such right. Environmental damage and deterioration will generate a liability for whoever provokes them in terms of the provisions by the law.
+
+Any person has the right of access, provision and drainage of water for personal and domestic consumption in a sufficient, healthy, acceptable and affordable manner. The State will guarantee such right and the law will define the bases, subsidies and modality for the equitable and sustainable access and use of the freshwater resources, establishing the participation of the Federation, local governments and municipalities, as well as the participation of the citizens for the achievement of such purposes.
+
+Any family has the right to enjoy a decent and respectable house. The law will set the instruments and supports necessary to achieve such objective.
+
+Any person has the right to identity and to be registered immediately after their birth. The State shall guarantee the compliance of these rights. The competent authority shall issue, without any cost, the first certified copy of the birth certificate or registration.
+
+The State, in all decisions it makes and all actions it carries out, will safeguard and comply with the principle of doing what is in the best interest of children, thus entirely guaranteeing their rights. Boys and girls have the right to having their nutritional, health, educational and recreational needs satisfied for their proper development. This principle should guide the design, enforcement, following up and evaluation of the public policies focused on childhood.
+
+Ascendant relatives and guardians have the obligation of maintaining and demanding the compliance of these rights and principles.
+
+The State will grant aid to individuals in order to assist with the compliance of the rights of children.
+
+Every person has cultural rights, has the right of access to culture and the right to enjoy state cultural services. The State shall provide the means to spread and develop culture, taking into account the cultural diversity of our country and respecting creative freedom. The law shall provide instruments that guarantee access and participation of any cultural expression.
+
+All individuals have a right to physical culture and the practice of sports. The State shall promote and stimulate this right by issuing laws on the matter.
+
+### Article 5
+
+No person may be prevented from performing the profession, industry, business or work of his choice, provided that it is lawful. This right may only be banned by judicial resolution, when third parties’ rights are infringed, or by government order, issued according to the law when society’s rights are infringed. No one can be deprived of legal wages, except by a judicial ruling.
+
+In each state, the law shall determine which professions require a degree to be practiced, the requirements for such degree and the appropriate authorities to issue it.
+
+No one can be compelled to work or render personal services without obtaining a fair compensation and without his full consent, unless the work has been imposed as a penalty by a judicial authority, which shall be subjected to the provisions established in the Article 123, sections I and II.
+
+Only the following public services may be mandatory, and always according to the respective law: military service, jury service, councilman service and positions granted through the direct or indirect vote. Electoral and census duties shall be mandatory and free; however, those services performed professionally shall be paid as provided by this Constitution and any applicable laws. Social professional services shall be mandatory and remunerated according to the law and with the exceptions established in it.
+
+Any contract, pact or agreement, which purpose is the demerit, loss or irrevocable sacrifice of a person’s liberty is prohibited.
+
+Any contract by which a person agrees to his own proscription or exile, or by which he temporarily or permanently waives his right to practice certain profession, industry or business shall not be authorized either.
+
+A work contract will oblige the person only to render the service mentioned in that contract during the term established by law, which may not exceed one year in detriment of the worker. The work contract cannot include the waiver, loss or damage of any political or civil right.
+
+In the event that the worker fails to fulfill said contract, he only may be subjected to civil liability, but never may be exerted any coercion on him.
+
+### Article 6
+
+Expression of ideas shall not be subject to judicial or administrative inquiry, except for those cases when such expression of ideas goes against the moral, privacy or the rights of third parties, causes perpetration of a felony, or disturbs the public order. The right of reply shall be exercised according to law. The State shall guarantee the right to information.
+
+Every person shall be entitled to free access to plural and timely information, as well as to search for, receive and distribute information and ideas of any kind, through any means of expression.
+
+The State shall guarantee access to information and communication technology, access to the services of radio broadcast, telecommunications and broadband Internet. To that end, the State shall establish effective competition conditions for the provision of such services.
+
+To accomplish the provisions of this article, the following points shall be observed:
+
+1. In order to exercise the right of access to information, the Federation, the States and the Federal District, according to their respective powers, shall act in accordance to the following basis and principles:
+	1. All information in custody of any authority, entity or organ of the Executive, Legislative and Judicial Powers, autonomous organisms, political parties, public funds or any person or group, such as unions, entitled with public funds or that can exercise authority at the federal, state or municipal level is public. This information may only be reserved temporarily due to public interest or national security, following the law provisions for this. The principle of maximum disclosure shall prevail when interpreting this right. The obligated subjects (obligors) must record every activity that derives from their authority, competence or function, the law will specifically establish the assumptions under the declaration of inexistence of information shall proceed.
+		2. Information regarding private life and personal data shall be protected according to law and with the exceptions established therein.
+		3. Every person shall have free access to public information, his/her personal data and in the case to the rectification of his/her personal data, without the necessity to argue interest or justification.
+		4. The mechanisms to access information and expedite review procedures shall be established. These procedures must be formalized before specialized and impartial autonomous agencies established by this Constitution.
+		5. Government agencies (obligors) shall record and keep their documents in updated administrative files, and shall disclose, through electronic media, the complete and updated information about the use of public resources and their management indexes so that the information allows accountability procedures in regard to the fulfillment of their objectives and the results of their performance.
+		6. The law shall establish procedures for governmental agencies (obligors) to disclose information concerning the use of public resources paid to individuals or companies.
+		7. Failure to comply with these dispositions in regard to the access to public information shall be penalized according to the law.
+		8. The Federation shall establish an autonomous, specialized, impartial and collegiate agency. It must have a legal personality; own assets; full technical, managerial and decision power over its budget and internal organization; and shall be responsible for guaranteeing the fulfillment of the right of access to public information and the protection of personal data held by public agencies (obligated subjects), according to the terms established by law.
+		The autonomous transparency agency established in this fraction will be governed by the transparency and access to public information law, as well as the law for the protection on personal data held by obligated subjects, in the terms established by the general law issued by the Congress to set the basic principles, basis and procedures for the exercise of the information rights.
+		This agency will be governed by the principles of certainty, legality, independence, impartiality, efficiency, objectiveness, professionalism, transparency and maximum publicity.
+		The autonomous transparency agency has competence to receive inquiries related to the right of access to public information and the protection of personal data from any authority, entity, organism or agency that belongs to any of the Executive, Legislative or Judicial Powers, as well as any autonomous agency, political parties public trusts and public funds, or any other person, group, union or organization that receives or use public resources or that exercise authority at the federal domain with exception of those issues that correspond to the jurisdiction of the Federal Supreme Court, in which case a committee of three Supreme Court Justices would decide the issue. The autonomous transparency agency has, also the competence to receive the inquiries from individuals in regard to the resolutions issued by the local autonomous specialized transparency agencies and the Federal District transparency agency that ruled the inexistence, reserve, and confidentiality of information or that refuses to disclose information according to the terms established by law.
+		The National Transparency Agency \[organismo garante\], ex oficio or by substantiated petition of the local agency from the States or the Federal District may receive or analyze the inquiries that due to its importance or transcendence are in the interest of the National Transparency Agency.
+		The law will determine the information that shall be considered as reserved or confidential.
+		The resolutions of the National Transparency Agency are mandatory, definitive and indisputable for the obligated subjects (obligors). Only in the cases that the resolutions may be considered to endanger public security according to the law in the matter, the Legal Councilor of the Federal Government may present a review inquiry to the Supreme Court.
+		The National Transparency Agency \[organismo garante\] shall be constituted by seven commissioners. To appoint them, the Senate, previous extensive consultation to social actors and by proposal of the different parliamentary groups, will appoint the commissioner with the vote of two-thirds of the Senators present in the session according to the vacancy that must be covered and following the procedure established by law. The President may oppose the appointment within ten business days. If the President does not oppose the appointment within the given days, then the person appointed by the Senate will assume the commissioner office.
+		Given the case that the President opposes the appointment, the Senate will present a new proposal to occupy the vacancy according to the previous paragraph. However, to approve the proposal the vote of three-fifths of the Senators present is required. If this second appointment were objected, the Senate, according to the procedures in the previous paragraph, with the approval of three-fifths of the Senators present would appoint definitively the commissioner that will occupy the vacancy.
+		The commissioner office will be held during seven years, and the commissioners shall fulfill the requirements provided in the fractions I, II, IV, V and VI of the article 95th of this Constitution. The commissioners shall not hold other office, have an additional employment, or other commission with exception of the non-profit chairs or offices related to charities and academic or scientific institutions. The commissioners can only be removed from office according to the terms in the Fourth Title of this Constitution and they will be subject to political trial.
+		The conformation of the National Transparency Agency shall promote gender equality.
+		The Commissioner President shall be selected by a peer process, through the secret vote of the commissioners. The Commissioner President will remain in office for three years, with the possibility of being reelected to other three years. The commissioner president must render an annual report before the Senate in the date and terms described by the law.
+		The National Transparency Agency \[organo garante\] shall have an Advisory Board, formed with ten council members that shall be elected by the vote of two thirds of the present Senators. The law will establish the procedures to present the proposals to the Senate. Each year, the two council members with longer tenure will be replaced, unless they were proposed and ratified for a second term in office.
+		The law will establish the emergency measures and procedures that the Agency could implement to guarantee the fulfillment of its decisions.
+		Every authority and public servant is compelled to help the National Transparency Agency and its Commissioners for the adequate performance of the Agency.
+		The National Transparency Agency will coordinate its actions with the Federal Superior Comptroller Office \[Entidad de Fiscalizacion Superior de la Federacion\], the entity specialized in archives and files, the organ in charge of gathering and process of statistical and geographical data, as well as, with the local agencies in the States and the Federal District in order to strengthen the accountability within the Mexican State.
+2. In matters of broadcasting and telecommunications:
+	1. The State shall guarantee the integration to the information and knowledge society of its population through a policy of universal digital inclusion crafted with annual and sexennial goals.
+		2. Telecommunications are deemed as public services of general interest and, therefore, the State shall guarantee that they are offered under competitive conditions, with quality, plurality, universal coverage, interconnection, convergence, continuity, free access, and free from arbitrary interferences.
+		3. Broadcasting is deemed as public services of general interest and, therefore, the State shall guarantee that it be offered with quality and under competitive conditions, to deliver the benefits of culture to the population, preserving plurality and veracity of the information so broadcasted, as well as the promotion of national identity values, contributing to the goals established in Article 3 of this Constitution.
+		4. The broadcasting of publicity or propaganda presented as information coming from news or reports is hereby prohibited; the conditions to be met by the content and the contracting of the service for its broadcasting to the public shall be established, including those relative to the liability of concessionaires with regard to the information broadcasted for thirds parties, without prejudice to the freedom of speech and broadcasting.
+		5. A statute shall establish a decentralized agency with technical, operative, decision-making and management autonomy, which shall provide non-profit broadcasting to secure access to the population at large in each and every one of the Federation’s jurisdictions, to media contents that promote: national integration; educational, cultural and civic training; gender equality; supply of impartial, timely and truthful information about national and international news, allowing for the broadcasting of independent productions, as well as the expression of diverse and pluralistic opinions that strengthen societal democratic life.
+		The agency shall have a citizens’ council to secure independence and an impartial and objective editorial policy. The council shall have nine members to be elected, after ample public consultation, with a two-thirds vote by the Senate or, during recess, by the Permanent Committee. Council members shall serve in staggered terms. Each year, the two most senior members shall be replaced unless ratified for a second term by the Senate.
+		The Senate or, during recess, the Permanent Committee, shall appoint the President of the agency, upon the proposal of the Federal Executive, with a two-thirds vote. The President shall stay in office for five years, and may be re-appointed for only one additional term. The President may only be removed with a two-thirds vote by the Senate.
+		The President of the agency shall present and annual report of activities to the Executive and Legislative branches, and he will appear before both chambers of Congress in accordance with the law.
+		6. A statute shall establish telecommunications consumers’ and audience’s rights, as well as the remedies for their protection.
+
+### Article 7
+
+Freedom of speech, opinion, ideas and information through any means shall not be abridged. Said right shall neither be abridged through any indirect means, such as abuse of official or private control over paper, radio electric frequencies or any other materials or devices used to deliver information, or through any other means or information and communication technologies aimed at impeding transmission or circulation of ideas and opinions.
+
+No statute or authority shall establish prior restraints, nor shall it abridge freedom of speech, which shall be subject to no other limitation than those foreseen in the first paragraph of Article 6 of this Constitution. Under no circumstances shall the assets used for the transmission of information, opinions and ideas be subject to seizure on the grounds of being an instrumentality of a felony.
+
+### Article 8
+
+Public officers and employees will respect the exercise of the right to petition provided that petition is made in writing and in a peaceful and respectful manner. Regarding political petitioning, only citizens have this right.
+
+Every petition must be decided in writing by the authority to whom it was addressed, who has the duty to reply to the petitioner within a brief term.
+
+### Article 9
+
+The right to peacefully associate or assembly for any licit purpose cannot be restricted. Only citizens of the Republic may take part in the political affairs of the country. No armed meeting has the right to deliberate.
+
+Meetings organized to make a petition or to submit a protest to any authority cannot be considered as unlawful, nor be broken, provided that no insults are uttered against the authority and no violence or threats are used to intimidate or force the decision of such authority.
+
+### Article 10
+
+The inhabitants of the United Mexican States have the right to keep arms at home, for their protection and legitimate defense, with the exception of those prohibited by the Federal Law and those reserved for the exclusive use of the Army, Navy, Air Force and National Guard. Federal Law will state the cases, conditions, requirements and places where inhabitants can be authorized to carry weapons.
+
+### Article 11
+
+Every person has the right to enter and leave the country, to travel through its territory and to move house without the necessity of a letter of safe passage, passport, safe-conduct or any other similar requirement. In the event of criminal or civil liability, the exercise of this right shall be subject to the judicial authority. Relating to limitations imposed by the laws on immigration and public health, or in respect to undesirable aliens residing in the country, the exercise of this right shall be subject to the administrative authority.
+
+In case of political persecution, any person has the right to seek political asylum, which will be provided for humanitarian reasons. The law shall regulate the cases in which political asylum should be provided, as well as the exceptions.
+
+### Article 12
+
+No titles of nobility, nor prerogatives and hereditary honors shall be granted in the United Mexican States. Furthermore, those granted by any other country shall have no effect.
+
+### Article 13
+
+No one can be tried under special laws or special courts. No person or corporation can have any privileges, nor enjoy emoluments, other than those given in compensation for public services and which must be established by the law. Military jurisdiction prevails for crimes and faults against military discipline; but, under no case and for no circumstance, military courts can extend their jurisdiction over persons who are not members of the Armed Forces. Civilians involved in military crimes or faults shall be put on trial before the competent civil authority.
+
+### Article 14
+
+No law will have retroactive effect in detriment of any person.
+
+No one can be deprived of his freedom, properties or rights without a trial before previously established courts, complying with the essential formalities of the proceedings and according to those laws issued beforehand.
+
+With regard to criminal trials, it is forbidden to impose any penalty which has not been expressly decreed by a law applicable to the crime in question, arguing mere analogy or majority of reason.
+
+In civil trials, final sentence must agree with the law writing or the legal interpretation thereof. In the case of lack of the appropriate law, sentence must be based on the general principles of law.
+
+### Article 15
+
+The United Mexican States disallow international treaties for extradition when the person to be extradited is politically persecuted, or accused of ordinary crime while having the condition of a slave in the country where he/she committed the crime, as well as the agreements or treaties that alter the human rights established by this Constitution and the international treaties signed by the Mexican State.
+
+### Article 16
+
+No person shall be disturbed in his private affairs, his/her family, papers, properties or be invaded at home without a written order from a competent authority, duly explaining the legal cause of the proceeding.
+
+All people have the right to enjoy protection on his personal data, and to access, correct and cancel such data. All people have the right to oppose the disclosure of his data, according to the law. The law shall establish exceptions to the criteria that rule the handling of data, due to national security reasons, law and order, public security, public health, or protection of third party’s rights.
+
+Only judicial authority can issue an arrest warrant. Such arrest warrant shall always be preceded by a formal accusation or charge of misconduct considered as criminal offence, punishable with imprisonment, provided that there is evidence to prove that a crime has been committed and that the defendant is criminally liable.
+
+The authority executing an arrest warrant shall bring the accused before the judge without any delay and under its sole responsibility. Failure to comply with this provision will be punished under criminal law.
+
+In cases of flagante delicto, any person may arrest the offender, turning him over without delay to the nearest authorities, which in turn, shall bring him before the Public Prosecution Service. A record of such arrest must be done immediately.
+
+The Public Prosecution Service may order arrest of the accused, explaining the causes of such decision, only under the following circumstances all together: a) in urgent cases, b) when dealing with serious offence, c) under reasonable risk that the accused could evade the justice and, d) because of the time, place or circumstance, accused cannot be brought before judicial authority.
+
+In cases of urgency or flagrancy, the judge before whom the prisoner is presented shall immediately confirm the arrest or order his release, according to the conditions established in the law.
+
+In the case of organized crime, and at the request of the Public Prosecution Service, judicial authority can order to put a person into hold restraint, complying with the terms of time and place established by law and without exceeding forty days, whenever necessary for the success of the investigation, the protection of people or legal goods, or when there is reason to believe that the accused could avoid the action of justice. The forty days term can be extended, provided that the Public Prosecution Service proves that the causes that originate hold restraint still remain. In any case, the hold restraint shall not last more than eighty days.
+
+The term organized crime is defined as the organization of three or more people gathered together to commit crimes in a permanent or frequent manner, in the terms provided by the correspondent law.
+
+No accused person shall be held by the Public Prosecution Service for more than forty-eight hours. After this term, his release shall be ordered or he shall be brought before a judicial authority. Such term may be duplicated in case of organized crime. Any abuse shall be punished by criminal law.
+
+Only a judicial authority can issue a search warrant at the request of the Public Prosecution Service. The search warrant must describe the place to be searched, the person or persons to be apprehended and the objects to be seized. Upon the conclusion of the search, a report must be compiled at the site and before two witnesses proposed by the occupant of the place searched or, in his absence or refusal, by the acting authority.
+
+Private communications shall not be breached. The law shall punish any action against the liberty and privacy of such communications, except when they are voluntarily given by one of the individuals involved in them. A judge shall assess the implications of such communications, provided they contain information related to the perpetration of a crime. Communications that violate confidentiality established by law shall not be admitted in any case.
+
+Only the federal judicial authority can authorize telephone tapping and interception of private communications, at the request of the appropriate federal authority or the State Public Prosecution Service. The authority that makes the request shall present in writing the legal causes for the request, describing therein the kind of interception required, the individuals subjected to interception and the term thereof. The federal judicial authority cannot authorize telephone tapping nor interception of communications in the following cases: a) when the matters involved are of electoral, fiscal, commercial, civil, labor or administrative nature, b) communications between defendant and his attorney.
+
+The judiciaries shall have control judges who shall immediately and by any means solve the precautionary measures requests and investigation techniques, ensuring compliance with the rights of the accused and the victims. An authentic registry of all the communications between judges and the Public Prosecution Service and other competent authorities shall be kept.
+
+Authorized telephone tapping and interception of communications shall be subjected to the requirements and limitations set forth in the law. The results of telephone tapping and interception of communications that do not comply with the aforesaid requirements will not be admitted as evidence.
+
+Administrative authorities shall have powers to search private households only in order to enforce sanitary and police regulations. Administrative authorities can require the accounts books and documents to corroborate compliance with fiscal provisions, following the procedures and formalities established for search warrants.
+
+The sealed correspondence circulating through the mail shall be exempt from any search and the violation thereof shall be punishable by the law.
+
+During peacetime, no member of the Army can be quartered in a private house against the owner’s will nor impose any requirements. During a war, soldiers can demand lodging, baggage, food and other requirements in the terms set forth by the applicable martial law.
+
+### Article 17
+
+Nobody can take justice into their own hands, nor have resort to violence to enforce his rights.
+
+All people have the right to enjoy justice before the courts and under the terms and conditions set forth by the laws. The courts shall issue their rulings in a prompt, complete and impartial manner. Court’s services shall be free, judicial fees are prohibited.
+
+The Mexican Congress shall enact laws to regulate collective actions. Such laws shall establish the cases in which each law applies, as well as the judicial proceedings and the remedies for redress. Only the federal judges have jurisdiction on these proceedings.
+
+The laws shall provide alternative mechanisms to resolve controversies. Regarding to criminal matter, the laws shall regulate application of such mechanisms, ensure redress and establish the cases in which judicial supervision is required.
+
+The sentences by which an oral proceeding ends shall be explained in a public hearing before the parties.
+
+Federal and local laws shall provide the necessary means to guarantee the independence of the courts and the full enforcement of their rulings.
+
+The Federation, the States and the Federal District must guarantee the existence of a quality public defender office and shall provide the conditions for a professional career service for the defenders. The defenders’ fees shall not be inferior to the public prosecutors’ fees.
+
+Imprisonment shall be forbidden as a way to punish exclusively civil debts.
+
+### Article 18
+
+Preventive custody shall be reserved for crimes punishable by imprisonment. Preventive prisons shall be completely separated from the prisons used for convicted persons.
+
+The prison system shall be organized on the basis of respect for human rights, as well as work, training, education, health and sports as a means to achieve inmate’s social rehabilitation, pursuing that he/she will not commit a crime again and following the benefits that the law establishes for him/her. Women and men shall be imprisoned in separate places.
+
+The Federation, the States and the Federal District can make and execute agreements to send the inmates convicted for crimes under its jurisdictions to serve their sentence in other prisons under a different jurisdiction.
+
+The Federation, the States and the Federal District shall establish, within the field of their respective powers, an integral justice system for minor offenders that shall be used for those persons that have been found guilty of committing or participating in a crime as stated by the law and that their age ranges from twelve years old and less than eighteen years old. The system shall guarantee the human rights recognized by this Constitution for every person, as well as those specific rights that due to the their status as a person under development have been granted to children. People under twelve years of age who have been found guilty of having committed or participated in a crime as stated by the law shall only be subjected to social assistance.
+
+The management of this system will be organized by institutions, courts and authorities specializing in justice administration and legal proceedings regarding teenagers. The system shall use advice, protection and treatment methods that apply on each particular case following the principles of comprehensive protection and superior interest of the teenager.
+
+If appropriate, alternative forms of justice should be used in this system. The judicial process for teenager’s justice shall be through an oral adversarial system in which due process shall be strictly followed as well as the principle of independence among authorities in charge of the process or the conviction. Measures imposed to teenagers shall be proportional to the misconduct and shall seek teenager’s social and family reintegration, as well as the complete development of his person and capabilities. Confinement shall only be used as an extreme measure and for the briefest period of time that applies to the case. Confinement can be applied only to teenagers above fourteen years old who have committed or participated in an act that the law describes as a crime.
+
+Mexicans who are serving imprisonment penalties in foreign countries may be brought to the United Mexican States to serve their sentences according to the rehabilitation systems provided in this article. Foreigners who are serving imprisonment penalties may be transferred to their countries, in accordance with international treaties. Prisoner must grant his/her consent for the transfer.
+
+Convicts may serve their sentence in the penitentiaries closer to their home, in order to encourage their reintegration to the community. This provision shall not be applicable to organized crime and to inmates who require special security measures.
+
+Special centers shall be created for preventive imprisonment and for penalties regarding organized crime. The competent authority can restrict communication between accused person or prisoner and third parties in the event of organized crime, except for defender. The authority also can impose measures of special surveillance on these inmates. This provision can be applied to other inmates who require special security measures.
+
+### Article 19
+
+Detentions before a judicial authority in excess of 72 hours, counted from the moment the accused is presented to the authority, are prohibited without presenting formal charges indicating the crime, place, time and circumstances of such crime; as well as the evidence of the crime and of the probable liability of the accused.
+
+The Public Prosecution Service can request of the judge preventive prison only when other precautionary measures are not enough to ensure the presence of the accused in his trial, the development of the investigation, the protection of the victim, witnesses or community, as well as when the accused is on trial or had been previously convicted for having committed an intentional crime. Also, the judge will order preventive prison, by its own motion, in the following cases: organized crime; deceitful homicide; rape; kidnap; trafficking in persons; crimes committed using firearms, explosives or other violent instruments; and serious crimes against national security, the right to freely develop personality and the public health.
+
+The law shall establish the cases in which the judge can revoke liberty granted to the individuals subjected to trial.
+
+The term to issue the association order may be extended only at the request of the accused, according to the procedure set forth by the law. Prolonging the detention shall be sanctioned by penal law. The authority in charge of the establishment where the accused is shall attract the judge’s attention if it does not receive a copy of the detention order or the extension request in the term indicated above as soon as the term ends. If the authority does not receive the detention order within the next three hours, the accused shall be freed.
+
+Every proceeding will treat only the crime or crimes mentioned in the detention order. If within the course of proceedings, another crime appears, it shall be charged on a separate investigation. Charge accumulation may be ordered, if appropriate.
+
+In the event that, after the detention order has been issued for an organized crime charge, the accused evades the justice or is transferred to a foreign judge, the trial and the expiry date of the criminal action will be suspended.
+
+Treatment during the arrest or imprisonment, any annoyance without legal justification, any tax or contribution in jails, constitute an abuse which the law shall correct and the authorities shall repress.
+
+### Article 20
+
+Criminal proceedings will be oral and adversarial. It shall be ruled by the principles of open trial, contradiction, concentration, continuity and contiguity.
+
+1. General principles:
+	1. Criminal proceedings shall aim elucidation of the facts, innocent person’s protection, preventing impunity and compensate the damages that the crimes had motivated.
+		2. In every hearing, a judge must be present. The judge cannot delegate to somebody else the submission and evaluation of evidence, which shall be done in a free and logic manner.
+		3. Only the evidence submitted in the hearing shall be used for the sentence. The law shall establish the exceptions for the above and the pertinent requirements in case that the nature of the evidence requires prior evaluation.
+		4. The trial shall be carried out before a judge who has not previously handled the case. All arguments and evidence shall be presented in a public, contradictory and oral manner.
+		5. The accuser must provide the evidence necessary to demonstrate defendant’s guilt according to the criminal types. Both parties are equal during the proceeding.
+		6. No judge can talk about the trial with one of the parties without the presence of the other one, taking always into account the principle of contradiction, except for the cases predicted by this Constitution.
+		7. Criminal proceeding can be terminated in advance, provided that the defendant agrees and according to the law. If the defendant, voluntarily and aware of the consequences, acknowledges his guilt and there is enough evidence to corroborate the charges, the judge shall call to a sentence hearing. The law shall establish the benefits granted to the defendant in case he accepts his guilt.
+		8. The judge shall convict only when the guilt of accused is certain.
+		9. Any evidence obtained by violating the defendant’s fundamental rights shall be null and void.
+		10. These principles shall be observed also in the preliminary hearings.
+2. Defendant's rights
+	1. The defendant is innocent until proven guilty through a sentence issued by a judge.
+		2. The accused has the right to remain silent. From the moment of his arrest, the defendant shall be informed about the charges against him and his right to keep silent, which cannot be used against him. All forms of intimidation, torture and lack of communication are forbidden and shall be punished by the law. Any confession made without the assistance of a defender shall have no weight as evidence.
+		3. Every arrested person has the right to be informed of the grounds of arrest and of his rights at the moment of his arrest and while appearing before the Public Prosecution Service or a judge. In the case of organized crimes, the judicial authority can authorize to keep the accuser’s name in secret.
+		The law shall establish benefits for the accused or convicted person who provides effective assistance in the investigation of felonies related to organized crime.
+		4. All witnesses and any other evidence submitted by the defendant shall be admitted within the terms established by law. Judicial authority shall assist the defendant to enforce appearance of those witnesses whose testimony he may request, in the terms set forth by the law.
+		5. The defendant shall be judged in an open trial by a judge or court. This provision may be restricted for reasons related to national security, public safety, protection of victims, witnesses and minors, disclosure of legally protected data or when the court considers that it is justified to do so.
+		In the case of organized crime, all acts performed during the investigation shall serve as evidence when they cannot be reproduced during the trial or there is a risk for witnesses or victims. The accused has the right to object or contest such evidence.
+		6. The defendant has the right to be provided with all the information on record in the proceeding for his defense.
+		The accused and his counsel can access to the investigation records: a) when the accused is under arrest, b) when he makes his statement or is interviewed, c) before the first hearing. Once the first hearing has been carried out, information on investigation cannot be kept in secret, except for exceptional cases determined by the law, whenever that is imperative to ensure the success of the investigation and provided that they are revealed in time to safeguard defendant’s rights.
+		7. The accused shall be tried within a term of four months in the case of crimes punishable with a maximum penalty of two years of imprisonment; and within a term of one year if the crime is punishable with a penalty exceeding such term, unless he requests a longer term to prepare his defense.
+		8. Defendant has the right to a lawyer, whom he shall freely choose even from the moment of his arrest. If he does not want a lawyer or cannot appoint one at the moment of request, the judge shall appoint a public defender.
+		The defendant has the right that his lawyer appears in every acts of the process. Defendant’s lawyer is obliged to appear in all the acts related to defendant’s proceeding.
+		9. Prison or arrest cannot be extended due to the lack of money to pay lawyer’s fees or any other monetary cause, civil liability or any other similar motive.
+		Preventive prison cannot exceed the time established by law as maximum punishment for the crime in question. In no case, preventive prison shall exceed the term of two years, unless defendant asks for a longer time to prepare his defense. If after said term a sentence has not been pronounced, the defendant shall be freed immediately while the trial continues. However, other precautionary measures may be used.
+		The duration of detention will count for the sentence term.
+3. Victim's rights:
+	1. The victim has the right to receive legal council, to be informed about the rights that this Constitution grants to his/her favor; and whenever he should so require it, to be informed about the state of the criminal proceedings.
+		2. The Public Prosecution Service must receive all the evidence submitted by the victim during the preliminary criminal inquiry as well as during proceedings. The Public Prosecution Service must carry out the necessary steps to assists the victim. The victim has the right to intervene in the trial and to use the legal instruments according to the law.
+		Whenever the Public Prosecution Service does not consider necessary to carry out the steps required by the victim, he must state the grounds of law and fact justifying his refusal.
+		3. The victim has the right to receive urgent medical and psychological assistance from the moment the crime was committed.
+		4. The victim has the right of reparation. Whenever it should be legally admissible, the Public Prosecution Service is obliged to require redress. The victim also can request such redress by himself. The judge cannot acquit the convict of redress in the case of conviction.
+		The law shall set forth agile procedures to enforce redress sentences.
+		5. The judge must keep in secret victim’s identity and other personal data in the following cases: minor involved; rape, trafficking in persons, kidnap, organized crime; and when necessary to protect the victim, always respecting the defendant’s rights.
+		The Public Prosecution Service shall ensure the protection of victims, offended parties, witnesses and all others who take part in the trial. The judges are obliged to oversee proper compliance with this obligation.
+		6. The victim can request the necessary precautionary measures to protect his rights.
+		7. The victim can contest, before the judicial authority, the Public Prosecution Service’s omissions in the criminal investigation, as well as the resolutions with reservation, lack of exercising, abandonment of criminal prosecution or proceeding suspension when redress has not been completed.
+
+### Article 21
+
+It is the Public Prosecution Service’s responsibility to investigate crimes together with police bodies, who shall work under the Public Prosecution Service’s command.
+
+The exercise of the criminal prosecution before the courts is exclusive to the Public Prosecution Service. The law shall define the cases in which civilians can exercise criminal prosecution before the judicial authority.
+
+Only judicial authority can impose penalties, modify them and state the pertinent term for them.
+
+It is the administrative authority’s responsibility to apply the penalties for breaking the regulations. Such penalties may be fines, arrest up to thirty-six hours or community work. The fine may be exchanged by the appropriate incarceration term, which shall never exceed thirty-six hours.
+
+If the offender is a laborer, worker or employee, he may not be fined for an amount exceeding one day of wage.
+
+If the offender is not a salaried worker, the fine shall not exceed the amount equivalent to one day of his income.
+
+The Public Prosecution Service can state exceptions to support exercising of criminal prosecution in the cases and conditions set forth by the Law.
+
+The President of the Mexican Republic can accept the jurisdiction of the International Criminal Court, provided that he has obtained Senate’s approval.
+
+Public security is a responsibility of the Federation, the Federal District, the States and the Municipal Councils. Public security includes prevention of crimes, investigation and prosecution, as well as punishment for breaking the administrative rules, according to the law and the respective provisions stated in this Constitution. Performance of the institutions in charge of public security shall be ruled by the principles of legality, objectivity, efficiency, professionalism, honesty and respect to the human rights acknowledged by this Constitution.
+
+Institutions in charge of public security shall be of a civil nature, disciplined and professional. The Public Prosecution Service and the police forces of three government levels shall coordinate each other to guarantee public security. They shall constitute the Public Security National System, which shall be subjected to the following provisions:
+
+1. There should be a regulation for selection, admission, training, continuance, evaluation, appreciation and certification of the members of public security institutions. The Federation, the Federal District, the States and Municipal Councils shall operate and develop public security actions in the field of their respective powers.
+2. There should be a criminal and personnel database for the public security institutions. No one can be recruited unless he has been duly certified and registered in the system.
+3. There should be public policies intended to the prevention of crimes.
+4. The community shall participate in processes like evaluation of the public security institutions and the policies intended to prevent crime.
+5. Funds for public security, provided by the federal government to the States and Municipal Councils shall be exclusively used for that purpose.
+
+### Article 22
+
+Penalties of death, mutilation, infamy, marks, physical punishments, torture, excessive fines, confiscation of assets, and other cruel punishments are prohibited. Every penalty shall be in proportion to the crime committed and to the legally protected interest.
+
+Appropriation of assets shall not be considered as confiscation when such appropriation is ordered by the authority for the payment of taxes, fines or civil liability. Appropriation in the following cases shall not be deemed as confiscation: a) appropriation of property ordered by the judicial authority under the terms provided by Article 109 in case of illicit enrichment; b) appropriation of seized goods that were abandoned by the owner; and c) appropriation of goods, which ownership has been declared extinct by a sentence. In the event of ownership extinction, there shall be a procedure according to the following regulations:
+
+1. Ownership extinction procedure shall be jurisdictional and autonomous from the criminal proceedings.
+2. Ownership extinction procedure shall be applied in cases of organized crime, drug trafficking, kidnapping, car theft, human trafficking and illicit enrichment. Ownership extinction procedure is to be applied to the following goods:
+	1. Those goods that are instrument, object or product of a crime, even though criminal responsibility has not been established by a sentence, as long as there is enough evidence to determine that the crime has occurred.
+		2. Those goods that are not part, instrument or product of a crime but that have been used to hide or mix crime assets, provided that the elements established in the previous clause have been met.
+		3. Those goods that have been used for the perpetration of a crime by a third party, if the owner was aware, but he did not notify to the proper authority or he did not try to stop it.
+		4. Those goods that are the property of third parties, but there are enough elements to conclude that they are the product of patrimonial or organized crime, and the accused of such felonies behaves like the owner.
+3. The affected person can use the appropriate legal instrument to demonstrate the licit origin of the goods, the good faith and the ignorance about misuse of the goods.
+
+### Article 23
+
+No criminal trial shall have more than three instances. No one can be tried twice for the same crime, whether he was acquitted or convicted. Acquitting form the instance is prohibited.
+
+### Article 24
+
+Every person has the right to have freedom of ethical convictions, of conscience and of religion, and to have or to adopt, as the case may be, the one of her preference. Such freedom includes the right to participate, individually or collectively, in both public and private ceremonies, worship or religious acts of the respective cult, as long as they are not a felony or a misdemeanor punished by law. No person is allowed to use these public acts of religious expression with political ends, for campaigning or as means of political propaganda.
+
+Congress cannot dictate laws that establish or abolish any given religion.
+
+Ordinarily, all religious acts will be practiced in temples, and those that extraordinarily are practiced outside temples must adhere to law.
+
+### Article 25
+
+The State shall command the development of the Nation to: be integral and sustainable; strengthen national sovereignty and democracy; and, through competitiveness, fostering economic growth, employment rates and a fair distribution of income and wealth, to allow the full exercise of liberty and dignity to individuals, groups and social strata, which security is protected by this Constitution. Competitiveness shall be understood as those conditions necessary to generate increased economic growth while promoting investment and job creation.
+
+The State shall promote the stability of public finances and of the fiscal system to create favorable conditions for economic growth and employment. The National Development Plan, the States and Municipals plans shall follow this principle.
+
+The State shall plan, conduct, coordinate and direct national economic activity and shall carry out the regulation and promotion of the activities required by public interest within the frame of liberties established by this Constitution.
+
+The public, social and private sectors shall contribute to the national economic development, with social responsibility, without detriment to other forms of economic activity that contribute to the development of the country.
+
+The public sector shall exclusively be in charge of those strategic areas established in Article 28, paragraph fourth of the Constitution. The Federal Government shall at all times keep ownership and control over agencies and public productive corporations that have been established. In the case of planning and control of the national power system, the public power transmission and distribution systems, as well as the exploration and exploitation of oil and other hydrocarbons, the Nation shall be empowered to carry on those activities pursuant to paragraphs sixth and seventh of Article 27 of this Constitution. In the aforementioned cases, a law shall establish the rules concerning the administration, organization, functioning, procurement and other legal acts to be executed by the State-owned companies, as well as the remuneration regime for the personnel, to guarantee its efficiency, efficacy, honesty, productivity, transparency and accountability in accordance with best practices; the law shall also determine other activities that they may carry out.
+
+Likewise, the State may, alone or together with the social and private sectors, stimulate and organize such areas, which are a priority for development, in accordance with the law.
+
+Social and private sector enterprises shall be supported and fostered under criteria of social equity, productivity and sustainability, subject to the public interest and to the use of the productive resources for the general good, preserving them and the environment.
+
+The Law shall establish mechanisms to facilitate organization and expansion of economic activity of the social sector: farming cooperatives (ejidos), workers’ organizations, cooperatives, rural communities, enterprises which are majority or exclusively owned by workers and, in general, all the different social organizations for production, distribution and consumption of such goods and services that are necessary for society.
+
+The law shall promote and protect economic activities carried out by private parties and it shall also generate those conditions necessary to foster private sector growth leading to the benefit of national economic development, promoting competitiveness and implementing a national policy aimed at industrial development that shall include sectorial and regional components, according to the terms set forth by this Constitution.
+
+### Article 26
+
+1. The State shall organize a democratic planning system to support national development, which shall provide solidity, dynamism, competitiveness, continuity and equity to economic growth for the political, social and cultural independence and democratization of the nation.
+	National objectives included in this Constitution shall determine national planning. National planning shall be democratic and deliberative. Through the democratic participation mechanisms, the planning system shall collect the different aspirations and demands from the whole society to include them into the development programs and to the National Development Plan. All the programs carried out by the federal government must be subjected to the National Development Plan.
+	The law shall empower the President of the Republic to establish the appropriate procedures of popular participation and consultation for the national democratic planning system, as well as the criteria to prepare, implement, control and assess the development plan and programs. The law shall determine which agencies shall be responsible for the planning process and shall also determine the basis upon which the President of the Republic shall coordinate, through agreements with state governments and through agreement with private parties, the activities intended to prepare and implement the National Development Plan. The National Development Plan shall take into consideration the continuity and necessary adaptations of the national policy for the industrial development, paying attention to sectorial and regional considerations.
+	The law shall define the intervention of the Mexican Congress in the democratic planning system.
+2. The State shall have a National System of Statistical and Geographical Information, which shall provide official data. All data contained in this system shall be used mandatorily for the Federation, the States, the Federal District and the Municipal Councils, according to the law.
+	The National System of Statistical and Geographical Information shall be ruled and coordinated by an organism, which shall have technical, and management autonomy, legal personality and its own assets. Such organism will have the necessary powers to regulate data collection, processing and publication of information.
+	The organism shall have a Board of Government composed by five members, one of them shall be the chairman of both the board and the organism. The five members shall be designated by the President of the United Mexican States and approved by the Senate, or by the Permanent Committee during recess.
+	The law shall define the organization and functioning of the National System of Statistical and Geographical Information, according to the principles of access to information, transparency, objectivity and independence. The law also shall establish the requirements to become a member of the board, as well as the tenure term and the staggered renewal of the members.
+	The members of the board may be removed only due to a serious cause. They cannot have any other job, position or assignment, except for unpaid services in educational, scientific, cultural or altruistic institutions. Board members shall be subjected to that established in the Title Four of this Constitution.
+3. The State shall establish a National Council for the Evaluation of the Social Development Policy, that shall be an autonomous entity with legal personality and own assets. This Council shall be responsible for the poverty measurement and the evaluation of programs, objectives, goals, actions of the policies related to social development, the Council may also issue recommendations according to the terms established by law, which also states the coordination mechanisms between this entity and the federal, local and municipal authorities to exercise its functions.
+	The National Council for the Evaluation of the Social Development Policy shall be formed with one president and six councilors that shall be Mexican citizens with recognition for their work in the private or social sector, the academia or by their professional merits. They shall have at least ten years of experience in the social development sector and they must not be affiliated with any political party or have been a candidate for public office through electoral process. The Councilors shall be appointed by two thirds of the present members of the Chamber of Representatives, according to the procedures established by law. The Mexican President may object the appointment within ten business days, if the President does not present any objection, the person appointed shall occupy the office of Councilor. Every four years, the two Councilors with higher seniority shall be substituted unless they were nominated and appointed for a second term in office.
+	The President of the National Council for the Evaluation of the Social Development Policy shall be appointed in the same manner as the previous paragraph and shall be in office for five years after this period, he/she could be reelected for one more period and may only be removed in the terms stated in the Fourth Title of this Constitution.
+	Each year, the President of the National Council for the Evaluation of the Social Development Policy shall present a report of activities before both Chambers of the Congress according to the law provisions.
+
+### Article 27
+
+The property of all land and water within national territory is originally owned by the Nation, who has the right to transfer this ownership to particulars. Hence, private property is a privilege created by the Nation.
+
+Expropriation is authorized only where appropriate in the public interest and subject to payment of compensation.
+
+The Nation shall at all time have the right to impose on private property such restrictions as the public interest may demand, as well as to regulate, for social benefit, the use of those natural resources which are susceptible of appropriation, in order to make an equitable distribution of public wealth, to conserve them, to achieve a balanced development of the country and to improve the living conditions of rural and urban population. Consequently, appropriate measures shall be issued to put in order human settlements and to define adequate provisions, reserves and use of land, water and forest. Such measures shall seek construction of infrastructure; planning and regulation of the new settlements and their maintenance, improvement and growth; preservation and restoration of environmental balance; division of large rural estates; collective exploitation and organization of the farming cooperatives; development of the small rural property; stimulation of agriculture, livestock farming, forestry and other economic activities in rural communities; and to avoid destruction of natural resources and damages against property to the detriment of society.
+
+The following elements are the property of the Nation: all natural resources of the continental shelf and the seabed of the islands; all minerals and substances that are in seams, layers, masses or deposits and that have a nature different from the components of the soil, such as minerals from which metals and metalloids are extracted; beds with gemstones or salt; salt mines formed by sea water; the products derived from rock breaking, when their exploitation requires underground works; minerals or organic deposits susceptible to be utilized as fertilizers; solid mineral fuels; petroleum and all solid, liquid or gaseous hydrocarbons; and the space located over national territory, according to the extension and terms established by International Law.
+
+The following elements are the property of the Nation, according to the extension and terms established by International Law: waters of the territorial sea; internal sea waters; waters of lagoons and estuaries permanently or intermittently connected with the sea; waters of natural lakes which are directly connected with streams constantly flowing; river and affluent waters, from the site where the first permanent, intermittent or torrential waters start to flow, to the mouth in the sea, lakes, lagoons or estuaries owned by the nation; waters of the continuous or intermittent currents and their direct or indirect affluent, whenever their bed serves as border of national territory or between two states, or when they flow from one state to another or cross the country’s border; waters of lakes, lagoons or estuaries, which vessels, zones or shores are crossed by borderlines dividing one or more states or between the country and a neighboring country, or when the shoreline serves as a border between two states or between the country and a neighboring country; waters of springs flowing from beaches, maritime areas, streams, vessels or shores; waters extracted from mines; and the internal beds, shores and banks. Underground waters may be freely extracted by artificial works and may be appropriated by the owner of the land. However, when the public interest so requires or whenever other uses are affected, the President of the Republic may regulate extraction and use of underground waters and, even, establish prohibited zones. The same criteria shall apply to other waters belonging to the nation. Any other waters not included in the foregoing list, shall be considered as an integral part of the land through which they flow. Nevertheless, if such waters are located in two or more properties, their use shall be considered as public, complying with provisions issued by the states.
+
+In the cases referred to in the two previous paragraphs, the dominion by the State shall be inalienable and imprescriptible, and the exploitation, use or development of those resources, be that by individuals or by corporations incorporated in accordance with Mexican laws, shall not be carried out but through concessions granted by the Federal Executive in accordance with the rules and requirements so established by the laws; exception be made of broadcasting and telecommunications concessions, which shall be granted by the Federal Telecommunications Institute. Legal norms regarding works or efforts to exploit minerals and others substances referred to in paragraph four shall govern the execution and oversight of those carried out, or that ought to be carried out as of their entry into force, regardless of the granting date of the concessions, and the breach thereof shall result in the termination of the concessions. The Federal Government is empowered to establish and revoke national reserves. Such declarations shall be made by the Executive in those cases and under the conditions set forth by the laws. No concession shall be granted in the case of radioactive minerals. The Nation shall exclusively carry out the planning and control over the national electric system, and over the power transmission and distribution utilities. No concession shall be granted in these activities, notwithstanding the power of the State to execute contracts with private parties in accordance with the laws, which shall determine the ways in which private parties may participate in all other activities related to the electric power industry.
+
+In the case of petroleum and solid, liquid or gaseous hydrocarbons found underneath the surface, dominion by the Nation shall be inalienable and imprescriptible, and no concessions shall be granted. In order to obtain revenue for the State and contribute to the long-term development of the Nation, the Sate shall explore for and exploit oil and other hydrocarbons through assignment to productive state-owned companies, or through contracts to be executed with them or private parties, in accordance with the implementing law. To fulfill the purpose of said allocations and contracts, the productive state-owned companies may enter into contracts with private parties. In any event, subsoil hydrocarbons shall remain property of the Nation and it shall be so expressed in the allocation and contracts.
+
+Only the State can use nuclear minerals to generate nuclear energy. The State shall regulate the use of nuclear minerals. Nuclear energy will be used only for peaceful goals.
+
+The Nation has sovereign rights and jurisdiction on the exclusive economic zone, situated outside and beside the territorial sea. The exclusive economic zone stretches from the seaward edge of the country’s territorial sea out to two hundred nautical miles. In cases where said zone should produce a superposition over the exclusive economic zones of other countries, fixing of the boundaries shall be done through agreements with such countries.
+
+The legal capacity to own Nation’s lands and waters shall be governed by the following provisions:
+
+1. Only Mexicans by birth or naturalization and Mexican companies have the right to own lands and waters, and to obtain exploitation licenses for mines and waters. The State may grant the same right to foreigners, provided that they agree before the Ministry of Foreign Affairs to consider themselves as Mexicans regarding such property and not to invoke the protection of their governments in reference to said property, under penalty of forfeiting the property in favor of the country. Foreigners cannot acquire properties within the zone that covers one hundred kilometers along the international borders and fifty kilometers along the beach.
+	The State can authorize foreign States to acquire real estate for their embassies or legations in the same city where federal government powers reside, in accordance to the principle of reciprocity and to the national public interest and at consideration of the Foreign Affairs Ministry.
+2. Religious associations, created in accordance with the terms provided in Article 130 and its regulatory law, can acquire, possess or manage properties essential for their religious activities.
+3. Public and private charitable institutions, devoted to public assistance, scientific research, education, mutual assistance to their members, or any other lawful purpose cannot acquire other real estate than that which is essential to fulfill their objective, according to the regulatory law.
+4. Corporations based on shares can own rural lands, but only in the extension necessary to fulfill their objective.
+	The maximum area of land that such class of companies can hold in ownership for agricultural, livestock farming or forest activities is equivalent to twenty five times the limits specified in section XV of this Article. The law shall determine the capital structure and minimum number of shareholders so that the lands owned by each shareholder do not exceed the limits established for small rural property. All individual rural properties, based on shares, will be cumulative for this purpose. Likewise, the law shall establish the requirements for the participation of foreigners in said corporations.
+	The law shall establish the registration and control procedures required to comply with the provisions of this section.
+5. Duly authorized banks, in accordance with the credit institutions law, can have capital imposed on urban and rural properties, but they cannot hold in property or in management, any more real estate than that which is entirely necessary to fulfill their direct objective.
+6. The Federal District, the States and Municipal Councils shall have full legal capacity to acquire and possess all the real estate required for public services.
+	Federal and State laws, according to their respective jurisdiction, shall establish the cases in which expropriation of private property is necessary for the public welfare, issuing the corresponding statement. Compensation for expropriation shall be based on the property value registered in the records of the land registry or Tax collector’s office, regardless such value has been defined by the owner or by the State and tacitly accepted by owner when paying taxes. Only the increased or decreased value of said private property, due to any improvements or deteriorations made after the tax appraisal, can be subjected to assessment by experts and to judicial resolution. Objects, which value is not fixed in tax collector’s office, can also be subjected to assessment by experts and to judicial resolution.
+	The Nation shall execute the actions established in this Article through judicial proceedings. During said proceedings and under the appropriate court’s order, which shall be issued within one month, administrative authorities shall occupy, manage, auction or sell the lands or waters in question along with their appurtenances. In no case may such actions be revoked by the corresponding authorities before the execution sentence is pronounced.
+7. The legal capacity of farming cooperatives and communal land is recognized and their ownership over the land is protected, whether for human settlements or for productive activities.
+	The law shall protect the wholeness of the indigenous groups’ lands.
+	In order to promote respect and strengthening of the community life of farming cooperatives and communal land, the law shall protect the lands for human settlements and shall regulate the uses of communal lands, forests and waters. The State shall implement actions to improve the quality of life of in such communities.
+	The law shall regulate the exercise of indigenous peoples’ rights over their land and of joint-title farmers over their parcels, respecting their will to adopt the best conditions for the use of their productive resources. The law shall establish the procedures whereby the members of a cooperative and indigenous people may: associate among themselves or with the State or with third parties; grant the use of their lands; transfer their land rights to other members of their rural community, in the event of farming cooperative. The law shall also set forth the requirements and procedures whereby the cooperative assembly shall grant their members private rights over land. In cases of transfer of ownership, the right of preference set forth by the law shall be respected.
+	Within a same rural community, no member of a cooperative can hold land exceeding five percent of the total land belonging to the farming cooperative. Land ownership must always adjust to the restrictions established in section XV.
+	The general assembly is the supreme authority of the farming cooperative or indigenous community, within the organizational structure and powers granted by law. The communal property commission is a body democratically elected according to the terms provided by the law. It is the representative organ of the farming cooperative and the one responsible to carry out the assembly’s decisions.
+	Restitution of lands, forests and waters to rural communities shall be done according to the terms provided in the law.
+8. The following actions are null and void:
+	1. All appropriation of lands, waters and mountains from towns, villages, settlements or communities, made by political chiefs, governors or any other local authority in contravention of the law published on June 25, 1856, and other applicable laws and provisions;
+		2. All concessions, arrangements or sales of lands, waters or mountains, made by the Secretariat of Public Works, the Department of the Treasury or any other federal authority from the first day of December, 1876, to this date, which have illegally invaded farming cooperatives, indigenous land or lands of any other kind belonging to towns, villages, hamlets or communities.
+		3. All demarcation procedures, transactions, transfers or auctions performed during the period mentioned in previous paragraph and made by companies, judges or federal or state authorities, which have illegally invaded farming cooperatives, indigenous land or lands of any other kind belonging to towns, villages, hamlets or communities.
+		The only lands excepted from the nullity herein mentioned are those which have been distributed in accordance with the Law published on June 25, 1856, and have been owned for more than ten years, provided that the area does not exceed fifty hectares.
+9. Division or distribution made with error or vice among neighbors of a rural settlement may be annulled at the request of the three quarters of the neighbors who possess one quarter of the lands in question; or at the request of one quarter of the neighbors who possess three quarters of the lands in question.
+10. (Repealed by the decree published on January 6, 1992)
+11. (Repealed by the decree published on January 6, 1992)
+12. (Repealed by the decree published on January 6, 1992)
+13. (Repealed by the decree published on January 6, 1992)
+14. (Repealed by the decree published on January 6, 1992)
+15. Large rural estates are prohibited in the United Mexican States.
+	Small agricultural property is defined as the land which area does not exceed one hundred hectares of irrigated or damp soil per person, or the equivalent in other kind of soil.
+	Equivalence: one hectare of irrigated soil equals two hectares of seasonal soil equals four hectares of good quality pastureland equals eight hectares of forest, mountain or arid pastureland.
+	The following properties are also considered as small agricultural property: a) up to one hundred and fifty hectares per person when the ground is dedicated to cotton cultivation if the lands are irrigated; b) up to three hundred hectares when dedicated to cultivate banana, sugar cane, coffee, henequen, rubber, palm, grapevine, olives, quinine, vanilla, cacao, agave, prickly pear or fruit trees.
+	Small livestock property is defined as the area that does not exceed the land necessary to maintain up to five hundred heads of big livestock or the equivalent in small livestock per person, in accordance with the law and with the fodder capacity of the soil.
+	When the owners or users improve the quality of land by reason of irrigation, drainage or any other works, the land will still be considered as small agricultural property, even if it exceeds the maximum limits established for good quality lands, provided that the requirements established by the law are met.
+	If the owner or user of a small livestock property improves the land and uses it for agricultural purposes, the area so utilized shall not exceed the limits mentioned under paragraphs second and third of this section corresponding to the quality of said lands before the improvement.
+16. (Repealed by the decree published on January 6, 1992)
+17. Federal and State Congresses shall enact laws establishing the procedures to transfer and divide out into plots large areas of land exceeding the limits set forth under sections IV and XV of this Article.
+	Excess land shall be partitioned and sold by the owner within a term of one year from the date of notification. If at the end of such term the excess land has not been transferred, it shall be sold by public auction. Under equal conditions, the right of preference established in the Statutory Law shall be respected.
+	Local laws shall organize the family estate, establishing which properties and goods must compose it. Family estate shall be inalienable and unencumbered
+18. All contracts and concessions executed by previous governments, since 1876 to date, which have resulted in monopolization of national lands, waters and natural resources, under one sole person or company are declared subject to review, and the President of the Republic is empowered to declare any of them null and void whenever they imply a serious damage to public interest.
+19. Based on this Constitution, the State shall establish the measures required to provide agrarian justice in a prompt and honest manner, in order to guarantee legal certainty in land ownership. The State shall provide legal advisers for farm workers.
+	All conflicts that could arise or are pending between two or more communities related to land limits or land ownership, are under federal jurisdiction. The law shall establish agrarian courts vested with autonomy and full jurisdiction, which shall be made up of judges proposed by the President of the Republic and approved by the Senate or by the Permanent Commission during recess period.
+	The law shall establish an agency that provides agrarian justice to peasant farmers.
+20. The State shall provide good conditions to achieve total development in rural communities, for the purpose of creating jobs, guaranteeing welfare of the peasant population and their participation in national development. The State shall stimulate agricultural, livestock and forestry activities for optimal uses of the land through infrastructure works, supply of raw materials, credits, training and technical support. The State shall also issue the statutory law for planning, organization, industrialization and marketing of agricultural and livestock production, since these are activities of public interest.
+	The comprehensive and sustainable rural development referred to in the previous paragraph shall also include, among its aims that the State shall guarantee the sufficient and timely supply of basic nourishment established by law.
+
+### Article 28
+
+In the United Mexican States, all monopolies, monopoly practices, state monopolies and tax exemptions are prohibited. Protectionist policies are also prohibited.
+
+Consequently, the law shall severely punish, and authorities shall efficaciously police, all concentration or hoarding of articles deemed of necessary consumption in one or few hands, which purpose is to generate a price increase; every contract, procedure or combination of producers, industrialists, traders or service entrepreneurs resulting in restraint of free trade and competition among themselves, or forcing consumers to pay unreasonable prices, and, in general, any action resulting in an exclusive, unwarranted advantage in favor of one or many determined persons with prejudice for the general public or a social class.
+
+The laws shall establish bases to set maximum prices for articles, commodities or products considered as essential for the country’s economy or for popular consumption. Such laws shall also define distribution of said articles, commodities and products, in order to prevent that unnecessary or excessive intermediation cause shortage or price increases. The law shall protect and promote the organization of consumers for the better protection of their interests.
+
+The functions carried out by the State in an exclusive manner in the following strategic economic sectors shall not be considered monopolistic: post, telegraph, radiotelegraphy; radioactive minerals and nuclear power generation; planning and control of the national power system and the public power transmission and distribution systems; the exploration and exploitation of oil and other hydrocarbons, pursuant to paragraphs six and seven of the 27th Article of this Constitution, as well as any other activity expressly determined by the laws issued by Congress.. Satellite communications and railroads are priority areas for national development, in accordance with Article 25 of this Constitution. The State shall protect national security and sovereignty when exercising its ruling power and, when granting concessions or permits, it shall maintain or establish its dominion of the means of communication in accordance with applicable laws.
+
+The State shall have the agencies and companies required to efficiently manage the strategic and priority areas, where it may participate alone or together with the private and social sectors.
+
+The State shall have a Central Bank that shall be autonomous in the exercise of its functions and its administration. Its primary objective shall be to attain the stability of the purchasing power of the national currency, strengthening the guiding role of the State with regard to national development. No authority can order the Central Bank to provide financing. The Sate shall have a public trust denominated Mexican Oil Fund for Stabilization and Development, which fiduciary agent shall be the Central Bank, that will be tasked, under the terms set forth by the laws, with receiving, managing and distributing revenues—taxes excluded—derived from allocations and contracts referred to in paragraph seven of Article 27 of this Constitution.
+
+Those functions carried out exclusively by the State through the Central Bank in the strategic areas of coining and note printing, shall not be deemed monopolistic. The Central Bank shall regulate exchange rates, as well as banking and financial services, in accordance with the law and with the intervention of any competent authorities. The Central Bank shall have all the necessary powers to carry out said regulation and the enforcement thereof. The management of the Central Bank shall be entrusted to the persons appointed by the President of the Republic with the consent of the Senate or the Permanent Committee, as the case may be. They shall hold office for the terms which duration and staggered sequences are best suited to the autonomous exercise of their duties; they may only be removed for a serious cause and they cannot hold any other employment, position or assignment, except for those in which they act in the name of the Bank, and those unpaid activities carried out in educational, scientific, cultural or charitable organizations. The persons in charge of the Central Bank may be subjected to impeachment in accordance with the provisions established in the Article 110 of this Constitution.
+
+The Executive Branch shall have coordinated regulatory agencies for the energy sector, denominated National Hydrocarbons Commission and Energy Regulatory Commission, in accordance with the terms set forth by the law.
+
+Unions and workers associations will not be considered monopolies, which have been constituted to protect their own interests. Producers’ cooperatives or associations will not be considered monopolies either, provided that their objective is to sell directly in foreign markets the domestic and industrial products which are the main source of wealth in the region where they are produced or which are not essential products. Such associations shall always be under the supervision or protection of federal or state government and shall obtain the previous authorization from the appropriate legislative body. Such legislative bodies can repeal any authorization granted to constitute the associations in question, by themselves or by the President of the Republic’s request.
+
+Privileges granted for a given period of time to authors and artists for them to produce their pieces of work and to inventors and those individuals who improve inventions will not be considered monopolies.
+
+The State can grant concessions for the provision of public services or for the exploitation and use of property owned by the Nation, except for the exceptions established by the law. The laws shall set forth the requisites and conditions to guarantee that licensed services will be efficient and goods will be used for society’s interest.
+
+The laws shall prevent concentration of State property in private hands. Concession of public services shall be carried out according to this Constitution.
+
+Subsidies can be granted to economic key activities, provided that such benefits general and temporary and do not impact substantially the Nation’s finances. The State shall supervise application of subsidies and evaluate their results.
+
+The State shall have a Federal Economic Competition Commission, which shall be autonomous, shall have legal entity and its own assets, and shall guarantee free competition and maximized turnout to the marketplace, as well as prevent, investigate and police monopolies, monopolistic practices, economic concentrations and any other restrictions to the efficient operation of markets, in accordance with the Constitution and the law. The Commission shall have all the necessary powers to: efficaciously accomplish its task, including the power to issue orders to remove competition barriers and free access to the marketplace; regulate access to essential raw materials, and order divestment of certain assets, rights, stakes or shares of economic agents, in the proportion needed to remove anti-competitive effects.
+
+The Federal Telecommunications Institute is an autonomous body, with legal entity and its own assets, tasked with the efficient development of broadcasting and telecommunications in accordance with this Constitution and the provisions set forth by the laws. To that end, it shall regulate, promote and oversee the use, enjoyment and exploitation of the radio electric spectrum, the networks and the performance of broadcasting and telecommunication services, as well as the access to active and passive infrastructure and to other essential materials, to guarantee what this Constitution provides in Articles 6 and 7.
+
+The Federal Telecommunications Institute shall also: be the authority with competence on economic competition for the broadcasting and telecommunications sectors, where the Institute shall exclusively exercise the powers established in this article and the laws in favor of the Federal Economic Competition Commission; regulate participants in those markets asymmetrically to efficaciously eliminate barriers to competition and free access to the marketplace; set limits to the national and regional concentration of frequencies, concessions and cross-ownership as a means to control several media units with broadcasting and telecommunication concessions serving a given market or geographical coverage area; and order the divestment of assets, rights or quotas necessary to secure compliance of these limits, to guarantee what this Constitution provides in Articles 6 and 7.
+
+The Institute shall have the power to grant, revoke, as well as authorize assignment, changes of control, ownership or operation of legal entities in connection with broadcasting and telecommunications concessions. The Institute shall notify the Secretary of the corresponding jurisdiction prior to rendering a decision, who may issue a technical opinion on the matter. Concessions may be for commercial, public, private or social use, the latter including community and indigenous use, in accordance with their purpose, and subject to the principles set forth in Articles 2, 3, 6 and 7 of this Constitution. The Institute shall set the amount of consideration to be paid for the award of these concessions, as well as for the authorization of services related to them, after receiving the opinion of the treasury authority. The opinions aforementioned shall not be binding and shall be issues within thirty days; once that term is elapsed, should the opinions be still pending, the Institute shall proceed with the corresponding proceeding.
+
+All concessions of radio electric spectrum shall be granted through a public call for bids, to ensure maximum participation, taking into consideration concentration phenomena to the detriment of public interest, and securing the least price level for final consumers; the economic factor shall not have controlling weight in the concession award decision-making process. Concessions for public or social use will be nonprofit and shall be awarded directly in accordance with the law and under conditions that shall guarantee transparency in the proceedings. The Federal Telecommunications Institute shall keep a public registry of all concessions. A statute shall provide for an effective punitive scheme that will include, as grounds for revoking the concession, among others, the breach of final resolutions in cases of anti-competitive conduct. When revoking a concession the Institute shall serve prior notice to the Federal Executive to allow, eventually, the exercise of its power as needed to secure the continuity of service.
+
+The Federal Telecommunications Institute shall guarantee that the Federal Government is awarded with all necessary concessions for the discharge of its functions.
+
+The Federal Economic Competition Commission and the Federal Telecommunications Institute shall be independent agencies in their functioning and decision-making processes, professional in the performance of their roles, and impartial in their proceedings; and shall be subject to the following \[rules and standards\]:
+
+1. They shall issue their resolutions with full independence;
+2. They shall execute their budget autonomously. The House of Representatives shall guarantee sufficient; budgetary allocations to allow a timely and efficacious discharge of their competences
+3. They shall enact their respective organizational charters with a special majority vote;
+4. They may only issue general administrative regulations for the discharge of their regulatory functions in their respective sectorial competence;
+5. The law shall guarantee, within each agency, the separation between the investigative and the adjudicating authorities in those proceedings of a contentious nature;
+6. Their boards shall meet the transparency and access to information standards. They shall deliberate en banc, and shall decide by majority vote; their sessions, agreements and resolutions shall be public with the exceptions to be determined by law;
+7. The general regulations, acts or omissions by the Federal Economic Competition Commission and the Federal Telecommunications Institute may only be subject to challenge through indirect constitutional adjudication \[amparo indirecto\], and shall not be subject to injunctive suspension. Only in those cases in which the Federal Economic Competition Commission imposes fines or orders divestment of assets, rights, quotas or shares, these decisions shall only be enforced once the constitutional injunction proceedings, if any, is resolved. Resolutions rendered through adjudicative proceedings may only be challenged if they are final, on the grounds of breaches committed during the proceedings or in the resolution itself; general regulations applied during the proceeding may only be challenged through the constitutional injunction initiated against such general regulation. Specialized judges and courts pursuant to Article 94 of this Constitution shall hear constitutional injunctions. No ordinary or constitutional appeals shall be admitted against interlocutory acts;
+8. The heads of the agencies shall present to the Executive and Legislative Branches an annual working plan and an account of their activities every trimester; they shall appear before the Senate annually, and before both Chambers of Congress pursuant to Article 93 of this Constitution. The Federal Executive may request to either Chamber of Congress the appearance before them of the heads of these agencies;
+9. The law shall promote governmental transparency in these agencies under principles of digital government and open data;
+10. Remuneration to be perceived by Commissioners shall be adjusted in accordance with Article 172 of this Constitution;
+11. Commissioners may be removed from their posts by the Senate with a two-thirds vote of its present members, on the grounds of gross fault in the discharge of their functions and in accordance with the provisions of the law; and
+12. Each agency shall have an Internal Comptroller whose head shall be appointed by the House of Representatives by a two-thirds vote of its present members, in accordance with the terms set forth by the law.
+
+The governing bodies of both the Federal Economic Competition Commission and the Federal Telecommunications Institute shall have seven Commissioners, including the Presiding Commissioner, to be appointed staggered upon the proposal of the Federal Executive with the consent of the Senate.
+
+The Presiding Commissioner of each agency shall be selected by the Senate among the Commissioners with a two-thirds vote of its present members, to serve for a four-year term, with only one reelection. When the appointment of the Presiding Commissioner falls upon a Commissioner whose term is to finish before the four-year term, then the presidency shall only last for the remainder of his term as Commissioner.
+
+Commissioners must meet the following requirements:
+
+1. Be a natural born Mexican citizen and enjoy both civil and political rights;
+2. Be of 35 years of age;
+3. Enjoy a good reputation and have no record of convictions for voluntary felony or crime with a sentence of more than one year;
+4. Have a graduate degree;
+5. Have at least three years of distinguished professional, public service or academic track-record substantially connected to economic competition, broadcasting or telecommunications, as it may correspond;
+6. Substantiate, in accordance with this provision, the technical knowledge required to discharge the responsibilities of the position;
+7. Not having been appointed, during the year prior to the appointment, Secretary of State, Attorney General of the Republic, senator or representative either at the federal or local level, Governor of any state, or Head of Government of the Federal District; and,
+8. In the case of the Federal Economic Competition Commission, not having had employment, appointment or managerial positions in companies that had been subject to any proceeding leading to sanctions before said agency in the previous three years. In the case of the Federal Telecommunications Institute, not having had employment, appointment or managerial positions in companies owned by commercial or private concessionaires or entities related to them, subject to the regulations of said Institute in the previous three years.
+
+Commissioners shall refrain from performing under any other employment, work, public or private commission, except for teaching positions; they shall refrain from hearing cases in which they may have a direct or indirect stake pursuant to applicable law, and shall be subject to the accountability regime set forth in Title Four of this Constitution and impeachment. A statute shall regulate the modality under which Commissioners may have contact with people representing regulated economic agents to discuss matters of their competence.
+
+Commissioners shall serve for nine years and under no circumstances will they be appointed for a second term. In case of vacancy of any position, a replacement shall be appointed to complete the remainder of the term, pursuant to the procedure set forth in this Article.
+
+Candidates to the position of Commissioner shall substantiate their compliance with the requirements set forth above before an Evaluation Committee formed by the heads of the Bank of Mexico, the National Institute for Educational Evaluation and the National Geographical and Statistical Institute. To that end, the Evaluation Committee shall hold hearings every \[time\] a vacancy opens, shall decide by majority vote and shall be presided by the most senior head of agency, who will have a quality vote.
+
+The Committee shall issue public calls to fill the vacancy. It shall verify candidates’ compliance with the requirements set forth in this Article and shall further administer a test of knowledge in the field to be taken by those candidates that meet them. The proceedings must observe transparency, publicity and maximized turnout standards.
+
+To prepare the test on knowledge, the Evaluation Committee shall consider the opinion of at least two higher education institutions and shall follow the best practices in the field.
+
+The Evaluation Committee shall send, to cover each vacancy, a list with a minimum of three and a maximum of five candidates with the highest scores. In case of not reaching the minimum number of candidates, a new public call for candidates shall be issued. The Executive shall select, from among the candidates in the list, the one to be proposed to the Senate for its consent. Consent by the Senate shall be given with a two-thirds vote of the present members, within thirty business days as of the day of filing of the proposal. When in recess, the Permanent Commission shall summon the Senate. In case the Senate rejects the candidate proposed by the Executive, the President of the Republic shall submit a new proposal in accordance with the previous paragraph. This procedure shall be repeated, as many times as needed should new rejections take place, until there is only one candidate approved by the Evaluation Committee in the list, who shall then be directly appointed Commissioner by the Executive.
+
+No act pertaining to the selection and appointment of Commissioners proceedings shall be subject to challenge.
+
+### Article 29
+
+In case of invasion, serious breach of the peace or any other event which may place society in severe danger or conflict, only the President of the Republic can suspend, throughout the country or in a certain region, those constitutional rights and guarantees which may constitute obstacles for the State to face the situation easily and rapidly as required by the emergency. For this purpose, the President must obtain the Congress of the Union’s approval, or in the recess, the Permanent Committee’s approval. Such suspension of constitutional rights and guarantees shall be temporary through general provisions, never can a suspension be applied on a single person. If suspension of constitutional rights and guarantees is requested within the period when the Congress is working, it shall grant the necessary authorizations for the President to cope with the situation. However, if suspension is requested during the Congress recess, the Congress will be convened immediately so it can agree about the authorizations required.
+
+However, the decrees enacted under the situations described in the previous paragraph cannot restrict or suspend the exercise of the following rights and principles: the right to non-discrimination, the right to legal personality, the right to life, the right of personal integrity, the right of protection to the family, the right to have a name, the right to have a nationality, the children’s rights, the political rights, the freedom of thought, the freedom of religion, the principles of legality and retroactivity, the prohibition on the death penalty, the prohibition on slavery and servitude, the prohibition of disappearance and torture, nor the judicial guarantees that are necessary to protect these rights and principles.
+
+Restriction or suspension of constitutional rights and guarantees should be based and justified on the provisions established by this Constitution, should be proportional to the danger, and should observe the principles of legality, rationality, notification, publicity and non discrimination.
+
+When the restriction or suspension of the constitutional rights and guarantees ends, because the deadline was met or the Congress so ordered, all legal and administrative measures taken during the restriction or suspension will be void immediately. The President of the Republic cannot make comments to the decree, through which the Congress revokes the restriction or suspension of the constitutional rights and guarantees.
+
+The decrees enacted by the President of the Republic, during the restriction or suspension of the constitutional rights and guarantees, shall be immediately reviewed by the Supreme Court of Justice of the Nation, which shall rule on their constitutionality and validity as soon as possible.
+
+### CHAPTER II. Mexican Nationals
+
+### Article 30
+
+Mexican nationality is acquired by birth or by naturalization.
+
+1. The Mexican nationals by birth are:
+	1. Those born in the Mexican territory, regardless of their parents’ nationality;
+		2. Those born in a foreign country which are sons/daughters of Mexican parents born in national territory, of Mexican father born in national territory, or of Mexican mother born in national territory;
+		3. Those born in a foreign country which are sons/daughters of Mexican parents by naturalization, of Mexican father by naturalization, or of Mexican mother by naturalization
+		4. Those born on board of Mexican military or merchant vessels or aircrafts.
+2. The Mexicans by naturalization are:
+	1. Those aliens who obtain a naturalization card from the Department of Foreign Affairs.
+		2. Any foreign woman or man who marries a Mexican man or woman and establishes residence inside the Mexican territory, provided that foreigner complies with the other requirements set forth by the law for that purpose.
+
+### Article 31
+
+Obligations of the Mexicans are:
+
+1. To make their children or pupils attend to the public or private schools to receive preschool, elementary, middle and higher education and the military \[education\] under the terms set by the law.
+2. To assist at the date and time established by the Municipal Council of their place of residence, to have civic and military training in order for them to be able to exercise their citizen rights and to have the appropriate knowledge about military discipline and fire arms handling.
+3. To join the Nation Guard, according to the pertinent organic law, in order to defend and assure the Nation’s independence, territory, honor, rights and interest, as well as to maintain the domestic peace an order.
+4. To contribute to the public expenditures of the Federation, the Federal District, the States or the Municipalities in which they have residence in the proportional and equity manners that the law has established.
+
+### Article 32
+
+The law shall regulate the exercise of the rights that the Mexican legislation grants to its citizens that also have a second nationality and shall issue norms to avoid double citizenship conflicts.
+
+The government positions and offices that by the terms established in this Constitution it is required to be a Mexican citizen by birth shall be reserved to those citizens that meet this criteria and that do not acquire another nationality. This provision shall also apply to the cases stated by other laws enacted by the Mexican Congress.
+
+During peacetime, foreigners shall neither serve in the Army nor in the police or security bodies. During peacetime, only Mexicans by birth can serve in the Army, in the Navy or in the Air Force as well can perform any employment or commission within such corporations.
+
+The same condition applies to captains, pilots, skippers, ship engineers, flight engineers and, in general, to every crew member in a ship or an airplane carrying the Mexican flag. In the same way, only Mexicans by birth can be port harbormasters, steersmen and airport superintendents.
+
+Mexicans shall have priority over foreigners, under equal circumstances, for all kind of concessions, employments, positions or commissions of the government in which the status of citizenship is not indispensable.
+
+### CHAPTER III. The Foreigners
+
+### Article 33
+
+The individuals that do not meet the criteria determined by Article 30 shall be considered as foreigners. They shall be entitled to the human rights and guarantees conferred by this Constitution.
+
+The President of the Republic shall have the power to expel from national territory any foreigner, according to the law and after a hearing. The law shall establish the administrative procedure for this purpose, as well as the place where the foreigner should be detained and the time that the detention lasts.
+
+Foreigners may not in any way participate in the political affairs of the country.
+
+### CHAPTER IV. The Mexican citizens
+
+### Article 34
+
+Mexican citizens shall be those individuals who are considered as Mexicans and fulfill the following conditions:
+
+1. To be at least 18 years old, and
+2. To have an honest way of life.
+
+### Article 35
+
+Rights of citizens:
+
+1. Right to vote.
+2. To be elected for all popular election positions, having met all the requirements set by the law. The right to request registration of candidates before the electoral authority corresponds to the political parties, as well as citizens requesting independent registration and who meet the requirements, conditions and terms set by the law;
+3. Right of assembly in order to peacefully participate in the country’s political affairs.
+4. Right to join Army or National Guard in order to defend the country and its institutions under the law.
+5. Right to petition
+6. To be appointed for any job or commission of the public service, having the qualities set by the law;
+7. To initiate laws, according to the terms and requirements established by this Constitution and the Law that governs the Congress. The National Electoral Institute will have the faculties granted in this matter by law; and,
+8. To vote in the referendum about national importance topics, which will be subject to the following:
+	1. They will be called by the Congress of the Union and requested by:
+		1. The President of the Republic;
+				2. The equivalent to thirty three percent of the members of any of the Chambers of the Congress of the Union; or
+				3. The citizens, in an equivalent number, at least, to two percent of those subscribed in the voting registration list, under the terms set by the law.
+		With the exception of the hypothesis mentioned in item c) above, the petition should be approved by the majority of each Chamber of the Congress of the Union.
+		2. When the total participation corresponds, at least, to forty percent of the citizens subscribed in the voters registration list, the result will be binding for the Federal Executive and Legislative powers and for the competent authorities;
+		3. The restriction of the human rights considered in this Constitution, the principles of article 40 therein; the electoral matter; State income and expenses; national security and the organization, operation and discipline of the permanent Army, may not be subject to popular consultation; The Supreme Court of Justice of the Nation will resolve, previous to the call by the Congress of the Union, about the constitutionality on the consultation matter;
+		4. The National Electoral Institute will be directly in charge of verifying the requirement set in item c) of section 1st of this paragraph, as well as the organization, development, account and declaration of results;
+		5. Referendum will be performed on the same federal electoral day;
+		6. The Rulings of the Electoral National Institute may be challenged under the terms stated in section VI of article 41, as well as section III of article 99 of this Constitution; and,
+		7. Laws will set the necessary provisions to make this section effective.
+
+### Article 36
+
+Responsibilities of Mexican citizens:
+
+1. To register himself at the respective tax office, declaring his property and profession or work. To register himself in the National Citizen Register, according to the law.
+	The National Citizen Register, its organization and permanent functions, as well as the issuance of the document that certifies the Mexican citizenship are public services under the State and citizen responsibility according to the provisions stated by the law.
+2. To join the National Guard.
+3. To vote in the elections and the referendum under the terms set by the law;
+4. To hold a federal or state elective office, which shall never be unpaid.
+5. To be councilor, electoral assistant and jury in the municipal council.
+
+### Article 37
+
+1. The Mexican nationality by birth shall never be revoked.
+2. The Mexican nationality by naturalization can be revoked in the following cases:
+	1. If the person voluntarily acquires a foreign nationality, pretends to be foreign citizen when subscribing any public document, uses a foreign passport or accepts or uses nobility titles which imply submission to a foreign State.
+		2. If the person lives abroad for five years in a row.
+3. Mexican citizenship can be revoked in the following cases:
+	1. If the person accepts or uses nobility titles issued by foreign governments.
+		2. If the person voluntarily provides services to or performs an official function for a foreign government without approval of the Federal Executive.
+		3. If the person accepts or uses foreign decorations without approval of the Federal Executive.
+		The President of the Republic, Senators and Representatives and Supreme Court Justices may freely accept and use foreign decorations.
+		4. If the person accepts titles or employment from other country’s government without approval of the Federal Executive, except by literary, scientific or humanitarian titles, which can be freely accepted.
+		5. If the person helps a foreigner or foreign government against the Nation in any diplomatic controversy or international court.
+		6. In any other cases as prescribed by the laws.
+
+### Article 38
+
+Citizens’ rights and prerogatives can be suspended in the following cases:
+
+1. Unjustifiably failure to comply with the duties imposed by Article 36. This suspension shall last for one year and shall be imposed along with any other punishment which can be applied for such failure under the law.
+2. If the person is on trial for a crime that deserves physical punishment. In such a case suspension starts from the date the detention order was issued.
+3. If the person is serving time in prison
+4. Due to vagrancy or customary inebriation, declared according to the law provisions
+5. If the person is a fugitive, from the moment in which the detention order has been issued to the moment when prosecution has expired.
+6. As a result of a sentence that imposes this suspension
+
+The law shall define the ways in which citizens’ rights will be revoked or suspended, as well as the recovery procedures.
+
+### TITLE TWO.
+
+### CHAPTER I. National Sovereignty and form of State Governance
+
+### Article 39
+
+The national sovereignty is vested, originally and essentially, in the people. Public power comes from the people and it is institutionalized for the people’s benefit. People, at all times have the inalienable right to change or modify its form of government.
+
+### Article 40
+
+It is in the will of the Mexican people to constitute into a representative, democratic, secular, federal, Republic, made up by free and sovereign States in everything related to its domestic regime, but united in a federation established according to the principles of this fundamental law.
+
+### Article 41
+
+People exercise sovereignty through the Powers of the Union and the state powers, according to the distribution of jurisdictions as it is established in this Constitution and the respective States’ Constitutions. The states’ constitutions, by no means shall challenge the stipulations and premises of the federal pact.
+
+The legislative and the executive branches of Federal Government shall be renewed by the means of free, authentic and periodical elections. Such elections shall be subjected to the following principles:
+
+1. Political parties shall be considered as entities of public interest. The legislation shall specify the norms and requirements for their legal registry and their participation in the electoral process, as well as their rights, duties and prerogatives entitled to them.
+	The political parties’ main objectives shall be: a) to promote people’s participation in democracy, b) to contribute to the integration of national representative entities and as citizens organizations, c) to allow access by citizens to public power, according to their programs, principles and ideas and through universal, free, secret and direct vote, as well as the rules to guarantee gender equality on candidates to local and federal Congress. Only citizens can form a political party and may join, individually and freely to them. Intervention of labor unions, social associations or any other group affiliation is prohibited.
+	Electoral authorities can intervene in the internal issues of political parties only within the scope of the law and this Constitution.
+	The national political parties will have the right to participate in the federal, local and municipal elections. The national political party that does not obtain, at least, three percent of the total valid votes emitted in any elections held for the renewal of the Federal Executive or the renewal of both the Senate and the Chamber of Deputies will have its registration cancelled.
+2. Federal law shall fairly provide national political parties with all necessary resources to carry out their political activities. The law shall also regulate financing system for the parties, in order to prevent private funding to prevail over public funding.
+	Public funding for political parties shall consist of: a) public financing directed to cover the expenses generated by their ordinary and permanent activities, b) public financing for electoral activities during electoral processes. Public funding will be provided according to the law and the following principles:
+	1. Public funding directed to cover ordinary and permanent activities shall be established annually according to the following method: To multiply the total quantity of citizens registered in the electoral register by sixty five percent of daily minimum wage in the Federal District. The thirty percent of the amount obtained by such calculus shall be equally distributed among political parties; seventy percent shall be distributed according to the vote percentage they have obtained at the previous House of Representatives election.
+	2. Public financing for electoral activities in the year when President of the Republic, senators and representatives are elected shall be equal to the fifty percent of public funding provided under the previous paragraph. Public financing for electoral activities in the year when only representatives are elected shall be equal to the thirty percent of public funding provided under the previous paragraph.
+	3. Public funding for specific activities, related to education, training, socioeconomic and political research and publishing activities, shall be equal to the three percent of the total public financing for all parties according to paragraph “a” per year. The thirty percent of the amount obtained by such calculus shall be equally distributed among political parties and seventy percent shall be distributed according to the vote percentage they have obtained at the previous House of Representatives election.
+	The law shall define limits for spending in the internal process for candidate selection, as well as for electoral campaigns. The law shall also establish maximum limits for monetary contributions provided by sympathizers and affiliates. The law shall also establish procedures to control and monitor the origin and use of financial resources of the parties, and shall determine the measures to punish any illegal activity in this respect.
+	The law shall establish procedures to help parties to pay their liabilities in the event that they lose registration, as well as to regulate the way their properties will be transferred to the State.
+3. National Political Parties have the right to use the media and social communication means permanently. Independent candidates shall have access to prerogatives for their electoral campaigns according to the law.
+	1. The National Electoral Institute shall be the only authority to manage media time for the State in radio and television to fulfill its own means and for the national political parties to exercise its rights, according to the law and to the following provisions:
+		1. From the run-up to the election campaign until the election day, the National Electoral Institute shall get forty eight minutes daily, distributed in two to three minutes segments per hour in each radio station and television channel, according to the schedule defined in paragraph “d” of this section. In the period between the run-up for the internal election and the beginning of the electoral campaign, the fifty percent of the time in radio and television shall be distributed to the goals and objectives of the electoral authorities and the remaining minutes shall be distributed to air generic messages from the political parties in the terms established by law.
+				2. During run-up, political parties shall get, jointly, one minute per transmission hour at each radio station and television channel. The remaining time shall be used according to the law.
+				3. During electoral campaigns, the media shall allocate at least eighty-five per cent of the time established in paragraph “a” of this section to political parties and candidates to guarantee their rights.
+				4. Transmissions about political parties in each radio station and television channel shall be distributed between 06:00 and 24:00 hours.
+				5. According to the rights of the political parties and, in a given case, to the independent candidates, airtime shall be distributed among them in the following way: seventy percent shall be distributed according to the vote percentage obtained by each political party at the previous House of Representatives election, the remaining thirty percent of airtime shall be equally distributed among political parties; from these equally distributed parts, up to one shall be assigned to all the independent candidates.
+				6. Political parties that are not present in the Mexican Congress shall only get the airtime in radio and television corresponding to the percentage, equally distributed among parties, mentioned in the last item.
+				7. Apart form the running-up period and the electoral campaigns, and with independence of the items a) and b) of this section, the National Electoral Institute shall get at radio and television airtime up to twelve percent of the total airtime allocated for the State, according to the law and under any modality. From this twelve percent, the National Electoral Institute shall equally allocate fifty percent between the political parties. The remaining fifty percent shall be used by the National Electoral Institute for its own purposes or another, federal or local, electoral authority. Every political party shall distribute its airtime according to the schemes provided by the law. In any case, the airtime shall be transmitted according to the schedule designed by the National Electoral Institute according to item d) of this section. In special occasions and with the proper justifications, the Institute might use the time that corresponds to party messages used to promote a political party.
+		Political parties or candidates cannot, in any time, buy airtime on television or radio by themselves or through third persons.
+		No private individual or legal entity can buy airtime on television or radio to influence political preference, or to promote or attack certain candidate or party. Such kind of media messages that have been contracted in a foreign country cannot be transmitted in the Mexican territory.
+		The States and the Federal District shall issue laws to enforce observance of the provisions established in the two previous paragraphs.
+		2. For electoral aims in the Mexican States, the National Electoral Institute shall allocate and manage the airtime in radio and television in stations and channels with coverage in the given state, according to the law and the following provisions:
+		1. In the event of state elections that coincide with federal elections, airtime for the state shall be included within the total time allocated in accordance with paragraphs “a”, “b” and “c” of section “A”.
+				2. For the rest of electoral processes, allocation shall be done according to the law and to the criteria provided in this Constitution.
+				3. Airtime distribution among the parties, including local parties and independent candidates, shall be carried out in accordance with the criteria established in section “A” and with the applicable legislation.
+		If the National Electoral Institute considers that total airtime in radio and television granted by this and the previous paragraphs were not enough for its own purposes, for another electoral authority’s purposes or for the independent candidates, it can issue orders to cover the deficit within the powers vested to it.
+		3. In the political and electoral campaign advertising, the political parties and candidates cannot use terms or expressions that denigrate or slander people.
+		During federal and local election campaigns until the election day, all governmental advertising shall be suspended, no matter it belongs to federal, state or municipal government, or to the Federal District government or to any other governmental agency. The only exceptions shall be: a) informative campaigns carried out by electoral authorities, b) educational and health campaigns and c) civil protection campaigns in the event of emergencies.
+		4. The National Electoral Institute, through expedited proceedings described by law, shall investigate the transgressions of these dispositions and will produce a file of these violations to present it before the Electoral Court of the Federal Judicial Power for their knowledge and consideration. During this procedure, the Institute may establish precautionary procedures such as the immediate cancellation or suspension of any message transmitted by radio or television, as established by the law.
+4. The law shall fix the terms and requirements for the selection and nomination processes for candidates to electoral positions. The law shall also establish the appropriate rules for run-up and electoral campaigns.
+	The duration of the electoral campaign when there are elections for the President of the Republic, senators and representatives shall be of ninety days. The duration of the electoral campaign shall be sixty days for the year that only representatives will be elected. Never the duration of run-up to the election campaign shall exceed two-thirds of the period granted for electoral campaigns.
+	Infringement of these provisions by parties, private individuals or legal entities will be punished according to the law.
+5. The State is responsible for the electoral organization. It is organized by the National Electoral Institute and by the local electoral institutes, according to the norms established by this Constitution.
+	1. The National Electoral Institute is an autonomous entity, which is endowed with legal personality and its own assets. The legislative branch, the national political parties and the citizens shall participate in the integration of the governing bodies of the Institute, according to the terms provided by law. The basic principles that guide the functions and performance of the Institute are: certainty, legality, independence, impartiality, objectivity and maximum publicity.
+		The National Electoral Institute shall have electoral jurisdiction and independent character regarding its decisions and functioning, and its performance shall be professional. National Electoral Institute structure shall include managerial, executive, technical and surveillance organs. The General Council will be the directive and executive body, it will be formed with one President of the Electoral Council and ten Electoral Councilors with the right to vote and participate in the debate; in addition, congressional Councilors, representatives of the political parties and an Executive Secretary, these will participate in the debate but will not be able to vote. Law shall regulate the organization and functioning of the Institute’s organs, the relationship between them and the relationship between them and the local electoral entities. The executive and technical organs shall employ the qualified personnel necessary to execute its attributions. The internal comptroller office shall be in charge of the accountability and surveillance procedures of all the incomes and expenses of the Institute, this office must be granted with managerial and technical autonomy to do so. The internal working relations and procedures with the public servants shall be regulated by the dispositions in the electoral law and the statute that the General Council approves. The surveillance organ of the electoral register \[padrón electoral\] must be formed mainly with representatives of the national political parties. During the election day, citizens must be in charge of the directive organs at the poll stations.
+		All the sessions of the directive and collegiate organs in the institution shall be public in the terms described by the law.
+		The Institute shall have an electoral office that is legally vested with public trust to attest for any electoral acts. The law will describe its attributions, powers and functioning.
+		The President of the Council and the Electoral Councilors shall be elected to serve for a period of nine years and may not be reelected. They shall be elected through the vote of two-thirds of the members present in the House of Representatives according to the following procedures:
+		1. The House of Representatives will present an agreement for the election of a President of the Electoral Council and the Electoral Councilors that will shall contain a public call, the stages of the process and the time limits, as well as the procedures to install a technical committee for the evaluation of candidates, this committee shall be formed with seven persons with professional recognition, three of this persons shall be nominated by the executive political organ at the House of Representatives, two by the National Commission for Human Rights and the remaining two shall be nominated by the National Transparency Agency \[organo garante\] established by the 6th Article of this Constitution.
+		2. The committee shall receive the list of all candidates for Electoral Councilor that present themselves to the call of candidates. The committee shall verify that the candidates fulfill the constitutional and legal requirements, as well as their suitability to occupy the office. It is responsibility of the committee to select five best candidates according to the evaluation for each vacancy, then the relation of candidates will be sent to the executive political organ at the House of Representatives.
+		3. The executive political organ at the House of Representatives shall promote agreements for the election of President of the Electoral Council and Electoral Councilors; this organ must hold an election to select the candidate in the terms described by law and then the proposal shall be sent to the floor of the House of Representative for its consideration.
+		4. The agreement stated in the item a) shall establish a time limit to have the election in the executive political organ at the House of Representatives, if this organ does not hold an election or do not sends the proposals stated in the previous item, or even when it has done all the proceedings but the required vote threshold has not been met then they shall call for a special session to reach a decision by drawing lots from the list of candidates presented by the evaluation committee.
+		5. In the case when no decision has been agreed according to the items c) and d) within the time limits described in item a), the Supreme Court of Justice, in a public hearing, shall make the election by drawing lots from the list of candidates presented by the evaluation committee.
+		Given the absolute absence of the President of the Electoral Council or from any of the Electoral Councilors during the first six years of their term in office, a substitute shall be elected to finish the corresponding period of the vacancy. If the absence happens during the last three years of the office period a new Electoral Councilor shall be elected for a new office period.
+		The President of the Electoral Council and the Electoral Councilors shall not have another employment or hold any other office or commission with exception of those that represent the General Council or the non-remunerated positions in academic, scientific, research, cultural or philanthropic associations.
+		The head of the Office of the Comptroller General of the Institute shall be designated by the vote of two thirds of the present members of the House of Representatives and by proposal of the public institutions of superior education, according to the terms described by law. The Comptroller General shall remain in office for six years and may only be reelected once. This office shall be administratively dependent of the General Council and will maintain the technical coordination with the Superior Comptroller General.
+		The Executive Secretary shall be appointed by two-thirds of the General Council after his nomination by the President of the Electoral Council.
+		The law shall establish the requirements that every individual must meet in order to be appointed as the President of the Electoral Council, Electoral Councilor, the Internal Comptroller or the Executive Secretary of the National Electoral Institute. Those individuals having served as President of the Electoral Council, Electoral Councilor or Executive Secretary may not hold a position in those public offices or powers where they were involved in the election of the members of that office or power, nor they can be hired by the executive organs of political parties or being candidates of public office for the next two years after their time in office at the Institute have concluded.
+		Congressional Councilors shall be appointed by the parliamentary groups with party affiliation in any of the two Chambers of Congress, at a ratio of one per each parliamentary group notwithstanding their recognition in both Chambers of the Congress.
+		2. The National Electoral Institute shall have the following attributions according to the terms established by this constitution and the laws:
+		1. For the federal and local electoral processes:
+			1. Electoral training;
+						2. Electoral geography as well as the design and delimitation of the electoral districts and the division of the territory into electoral sections;
+						3. The electoral registration list.
+						4. The location of electoral polls and the designation of the functionaries at the directive board for each poll station;
+						5. The criteria, guidelines, formats and rules for the preliminary results program, the opinion or result surveys, electoral observation, rapid counts, document printing and production of any electoral materials;
+						6. The accountability for income and expenses of the political parties and candidates;
+						7. And any other that the law establishes.
+				2. For the federal electoral processes:
+			1. The rights and prerogatives that the candidates and political parties have access to;
+						2. The preparation for the election day;
+						3. Document printing and the production of electoral material;
+						4. The count and scrutiny of the votes according to the terms established by law;
+						5. Declaring the validity of the election and issuing the electoral certification for the elected deputies and senators;
+						6. The count of the votes for President of the Mexican United States in every uninominal electoral districts;
+						7. Others established by law.
+		The National Electoral Institute may assume, by agreement with the competent authorities at the local entities that ask for, the organization of the local electoral processes in the terms that the applicable legislation states. By petition of the political parties and using their monetary prerogative, the institute may also organize their internal elections to elect their leadership.
+		The financial accountability and supervision of the political parties and the candidates’ campaigns shall be responsibility of the General Council of the National Electoral Institute. The law shall detail the General Council attributions for that specific function as well as the creation of the technical organs, dependent of it, in charge of the surveillance and proceedings to establish the corresponding sanctions. For the accomplishment of this function, the General Council is not limited by banking, fiscal or fiduciary secrecy and shall be supported and assisted by the local and federal authorities.
+		In case that the National Electoral Institute delegates the accountability and supervision functions, its technical organ shall be entitled to the attributions of the previous paragraph to avoid the limitation of its functions.
+		3. In the Mexican states the local elections shall be the responsibility of the Local Public Organs in the terms that this constitution establishes and shall execute the corresponding functions in regard to the following subjects:
+		1. The rights and prerogatives that the candidates and political parties have access to;
+				2. Civic education;
+				3. Preparation for the election day;
+				4. Document printing and the production of electoral material;
+				5. Count and scrutiny of the votes according to the terms established by law;
+				6. Declaring the validity of the election and issuing the electoral certification for the elected local officers;
+				7. Count and scrutiny for the election of the local executive power;
+				8. Preliminary results, opinion and results surveys, electoral observation and rapid counts according to the guidelines established in the previous part;
+				9. Organization, development, count and announcement of the results in the corresponding civic participation means provided by the local legislation;
+				10. Every other function not reserved to the National Electoral Institute;
+				11. Others that the law establishes.
+		According to the postulates established by the law and with the approval of a majority of at least eight votes at the General Council, the National Electoral Institute may:
+		1. Directly assume the execution of activities regarding the electoral functions that corresponds to the local electoral organs;
+		2. Devolve in the local organs the attributions described in the section a) from part B of this article without giving up the right to resume its direct exercise at any moment;
+		3. Bring to its knowledge any matter competence of the local electoral organs when its transcendence or importance requires so or when the matter shall be used to establish an interpretation criterion.
+		The National Electoral Institute shall have the attribution to appoint or remove the members of the executive organ at the local public organs in the terms established by this constitution.
+		4. The National Electoral Professional Service shall include the selection, hiring, training, professionalization, promotion, evaluation, personnel rotation, permanence and discipline of the public servants of the executive and technical organs at the National Electoral Institute and the local public organs at the federative entities in regard to electoral matters. The National Electoral Institute shall standardize the organization and functioning of the Professional Service.
+6. A judicial appeal system shall be established in accordance to this Constitution and to the law in order to protect the constitutionality and the legality principles, under which electoral decisions and resolutions must be made. Such system shall provide definitive resolutions in every stage of election process and shall protect the citizens’ political right to vote, right to be elected and right to assembly, according to the Article 99 of this Constitution.
+	In the electoral matters, legal or constitutional appeals will not result in the suspension of the appealed resolution or act.
+	The law will establish the electoral nullification system for the local and federal elections due to serious, fraudulent and determinant violations according to the following cases:
+	1. When the campaign expenses exceed five percent of the total amount authorized
+	2. When informative coverage or airtime in radio or television were bought without regard to the postulates specified in the law.
+	3. When public resources or resources from illicit origin are received or used for the campaign finance.
+	The previous violations shall be presented in a physical and objective manner. Violations shall be presumed to be determinant when the voting difference between the first and second candidate is less than five percent.
+	In case a nullification of the election, an extraordinary election shall be announced and the rebuked person will not be able to run for office.
+
+### CHAPTER II. Composition of the Federation and Mexican Territory
+
+### Article 42
+
+National territory is composed of:
+
+1. The territory belonging to the states.
+2. The territory of islands, including the reefs and cays in adjacent seas.
+3. The territory of the islands of Guadalupe and Revillagigedo located in the Pacific Ocean.
+4. The continental shelf and the seabed of the islands, cays and reefs.
+5. The waters of the territorial seas in the extension and under the terms established by the International Law and domestic maritime laws.
+6. The air space located above national territory, in the extension and with the particularities established by the International Law.
+
+### Article 43
+
+The Mexican territory is comprised of the following states: Aguascalientes, Baja California, Baja California Sur, Campeche, Coahuila de Zaragoza, Colima, Chiapas, Chihuahua, Durango, Guanajuato, Guerrero, Hidalgo, Jalisco, State of Mexico, Michoacán, Morelos, Nayarit, Nuevo León, Oaxaca, Puebla, Querétaro, Quintana Roo, San Luis Potosí, Sinaloa, Sonora, Tabasco, Tamaulipas, Tlaxcala, Veracruz, Yucatán, Zacatecas and the Federal District.
+
+### Article 44
+
+The Mexico City is the Federal District and the capital of the United Mexican States. Mexico City is seat of the federal government and the Powers of the Union. It shall be integrated by its current territory and in the event that federal government has to be moved to another place, Mexico City will be a part of the State of Valle de México. The Congress shall set down the limits and territorial extension for the new State.
+
+### Article 45
+
+The states will keep their current borders and extensions, as long as there is not a controversy about it.
+
+### Article 46
+
+The States can deal with their respective limits by friendly agreements among each other at any time; however, these arrangements will not be effective without the approval of the Senate.
+
+Should there not be an agreement referred in the above paragraph, and at the request of any of the conflicting parties, the Supreme Court of Justice of the Nation will know, substantiate and resolve with an unassailable capacity, disputes on territory limits that take place between States, and under the terms of section I of article 105 of this Constitution.
+
+### Article 47
+
+The State of Nayarit shall have the territorial area and boundaries that presently comprise the territory of Tepic.
+
+### Article 48
+
+Federal government shall be in charge of: a) all the islands, cays and reefs within the adjacent seas belonging to national territory; b) the continental shelf; c) the seabed of islands, cays and reefs; d) territorial seas; e) inland maritime waters and f) the space located above the national territory; except by the islands that belong to the states.
+
+### TITLE THREE.
+
+### CHAPTER I. Division of Powers
+
+### Article 49
+
+The political authority or power is divided into the Executive, the Legislative and the Judiciary branches. Two or more of these powers cannot be united in one single person or corporation, nor shall the legislative branch be vested in one single person, except for the case where extraordinary powers are granted to the President of the Republic as provided in Article 29. In no other case, except as provided under the second paragraph of Article 131, extraordinary powers to legislate shall be granted.
+
+### CHAPTER II. The Legislature
+
+### Article 50
+
+The legislative power is vested in the Congress of the United Mexican States, which shall consist of a Senate and House of Representatives.
+
+### Section I. Elections and Inauguration of the Congress
+
+The House of Representatives is composed by representatives of the nation. All of them shall be elected every three years. For each representative, a substitute shall be elected.
+
+### Article 52
+
+The House of Representatives shall be integrated by 300 members, who shall be elected according to the principle of majority voting through the uninominal voting system in all the electoral districts; and the remaining 200 members shall be chosen according to the principle of proportional representation, using a system of regional lists voted in multimember districts.
+
+### Article 53
+
+The borders separating the 300 uninominal electoral districts from each other shall be set down after dividing the country’s population by the number of districts, taking into account the most recent census. Each state shall have at least two representatives elected under the principle of majority voting.
+
+In order to elect 200 representatives under the principle of proportional representation, using a system of regional lists, five multimember electoral districts shall be established in the country. The law shall set down the ways in which such territorial division will be made.
+
+### Article 54
+
+The election of the 200 representatives under the principle of proportional representation, using a system of regional lists, shall be subjected to the following principles:
+
+1. To register its regional list, a political party must prove that it participates with candidates to the House of Representatives to be elected by the principle of majority voting in at least two hundred uninominal districts.
+2. Every political party attaining at least three percent of the total votes casted for the regional lists at the multimember constituency shall be entitled to have representatives under the principle of proportional representation.
+3. The political party complying with the two principles above established, shall obtain the number of representatives from the list corresponding to each multimember district, according to the way the people vote on that constituency. The order established in the regional lists shall be respected to appoint the candidates.
+4. No political party shall have more than 300 representatives, regardless the principle by which they have been elected.
+5. The political parties shall never have a number of representatives by both principles, which considered in percentage of the House, exceeds by eight points the percentage they have obtained in vote. This restriction shall not be applied to the political party that, due to its electoral victories at uninominal districts, obtains a percentage of seats greater than the addition of the percentage obtained in national vote plus eight percent.
+6. After that seats have been distributed according to previous paragraphs III, IV and V, the leftover proportional representation seats shall be awarded to the remaining political parties which have a right in each one of the multimember districts, in direct proportion to the national and effective votes received by these parties. The law shall regulate procedures and formalities to apply this article’s principles.
+
+### Article 55
+
+Requirements to be a Representative:
+
+1. To be a Mexican national by birth in the full exercise of his rights.
+2. To have attained to the age of twenty-one years on the election date.
+3. To be a native or resident of that state in which he/she shall be chosen for at least six months before the election date.
+	In order to qualify for registration in the regional lists of multimember districts, the candidate must be a native of one of the states included in such multimember district, or be a resident of that district for at least six months prior to the date of the election.
+	Residence is not lost in cases where absence is because he/she has been elected to a public office.
+4. To be free of duties at the Army, law enforcement agencies and rural police forces with jurisdiction over the electoral district in which the election is going to take place, at least ninety days before the election date.
+5. Not to be in charge of one of the organs, granted with autonomy by this Constitution. Not to be Secretary or Undersecretary of State. Not to be in charge of one of the decentralized organs of the federal government, unless the candidate is definitely separated from his duties at least 90 days before election date takes place.
+	Not to be Justice of the Supreme Court of Justice, Magistrate, Secretary at the Electoral Court of the Judicial Power of the Mexican Federation, President of the Council or Electoral Councilor in the General Council, Local or District Councils at the National Electoral Institute, nor Executive Secretary, Executive Director or directive personnel of this Institute, unless the candidate has definitely separated from his duties at least three years before election date takes place.
+	State Governors and the Federal District Mayor cannot be elected to represent the states over which they have jurisdiction, even though they definitely separate themselves from their duties.
+	State Secretaries, the Secretaries of the Federal District, the federal or state judges, the judges of the Federal District, the mayors in the states and persons in charge of any political-administrative entity in the Federal District, cannot be elected in the states where they exercise their respective duties, unless they resign their positions definitively at least ninety days before the election.
+6. Not to be priest or minister of any religion.
+7. To be unaffected by the inabilities established under article 59.
+
+### Article 56
+
+The Senate shall be composed of 128 senators, two Senators from each state and the Federal District elected in accordance to the principle of majority voting and one Senator shall be apportioned to the largest minority. For this purpose, political parties must register a list with two sets of candidates. The largest minority seat shall be granted to the set of candidates heading the list of the political party that shall have attained the second place in the number of votes casted in the corresponding state.
+
+The remaining thirty-two senators shall be elected under the principle of proportional representation, through the system of lists voted in one sole national multimember district. The law shall establish the regulations and formalities that shall be applied for these purposes.
+
+The Senate shall be totally renewed every six years.
+
+### Article 57
+
+There shall be an elected substitute for each senator.
+
+### Article 58
+
+The Senators shall fulfill the same requirements than the Representatives, except by the age. All senators must be at least 25 years old on the election date.
+
+### Article 59
+
+Senators may be elected up to two consecutive periods and the deputies of the House of Representatives may be elected up to four consecutive periods. The candidate may only be nominated by the same party by which the congressmen/women was elected or by any of the parties that formed the coalition by which the congressmen/women were elected, unless that they had resigned or lost their membership to the party in the first half of their mandate.
+
+### Article 60
+
+The National Electoral Institute established in the Article 41 of this Constitution and in accordance to the legal dispositions, shall declare the validity of the elections for both, representatives and senators in each one of the uninominal districts, as well as in each state. The National Electoral Institute shall also issue the respective certificates to the candidates who have obtained the majority of votes. The National Electoral Institute shall appoint the senators corresponding to the largest minority, according to the Article 56 of this Constitution and the law. Likewise, the National Electoral Institute shall declare validity of the election and shall appoint the representatives corresponding to the principle of proportional representation, in accordance to the Article 54 of this Constitution and the law.
+
+The resolutions made on validity of the election, on awarding certificates and on the appointed representatives or senators can be appealed before the regional courts of the Electoral Court of the Judicial Power, according to the procedures established by law.
+
+The regional court’s rulings may be reviewed only by the High Court of the Electoral Court of the Judicial Power, through the appeals submitted by political parties, provided that such offences could modify an election result. The verdicts given by the High Court of the Electoral Court of the Judicial Power shall be definitive and irrefutable. The law shall establish the conditions, requirements and formalities for such appeal system.
+
+### Article 61
+
+Representatives and senators shall be above criticism related to their opinions in the performance of their duties; they may never be questioned for such opinions.
+
+The speaker of each House shall be responsible for enforcing respect to House members’ constitutional immunity and to the inviolability of the place where the House of Representatives meets.
+
+### Article 62
+
+No Senator or Representative shall, during the time for which he was elected, be appointed to any federal or state government office which grants emolument without a license granted by the respective House. In such case, representative duties shall be suspended for as long as their new occupation lasts. The same rule shall be applied to the substitute representatives and senators if they have been called to service. Removal from office shall be the punishment imposed on any offender of this article’s rules.
+
+### Article 63
+
+In order to open sessions and to exercise the duties of the offices, the House of Representatives and the Senate shall have more than fifty percent of attendance of the total number of their members. Those present shall compel the absentees to attend within the next thirty days, under the condition that if they do not present themselves the Chamber shall understand that they do not accept their office. In such case, the substitutes shall be called, they must appear within the next thirty days. In the event that substitute does not appear either, the seat shall be declared vacant. All vacancies shall be filled, no matter if the vacancy happened at the beginning of legislature or during the legislative period. Regarding Representatives or Senators elected under the principle of majority voting, the respective House shall call extraordinary elections according to the Article 77, paragraph IV of this Constitution. Regarding representatives appointed by the principle of proportional representation, the next candidate in the regional list of the party in question shall fill vacancy. Regarding Senators appointed by the principle of proportional representation, the next candidate in the national list of the party in question shall fill vacancy. Regarding Senators appointed by the principle of largest minority, vacancy shall be filled by the second candidate in the list of the party in question of the respective state.
+
+Representatives and Senators shall inform their Speaker about absences. Any Representative or Senator who have been absent from his duties for ten days in a raw without the permit of the Speaker or justified cause shall not be allowed to take his seats back until the opening of the following period of sessions. In such a case, substitutes shall be called to service.
+
+In the event of lack of quorum in either House so that the legislature can be opened or to exercise their duties, the substitute shall be called immediately to attend as promptly as possible, while the aforesaid thirty days term elapses.
+
+Those Representatives or Senators that being elected do not present themselves to fulfill their duties and without a justified cause for the absence, shall be liable and subjected to the penalties established by the law.
+
+National political parties shall also be liable and subjected to the penalties set forth by the law if they agree with their candidates not to appear in the respective House to perform their duties.
+
+### Article 64
+
+Representatives and Senators who, unjustifiably and without a permit, are absent from one session, shall not be entitled to claim any wage for that particular day.
+
+### Article 65
+
+The Congress shall assemble every year on September 1st, for the first ordinary period of sessions, except for the year when the President of the Republic begins his term in office on the date described in the Article 83 of this Constitution. In this case the Congress shall meet from August 1st. For the second ordinary period of sessions, the Congress shall meet every year on February 1st.
+
+In both periods of sessions, the Congress shall study, discuss and vote the bills of law submitted thereto and shall resolve any other affairs pertaining to it according to this Constitution.
+
+The Congress shall preferably devote itself to the issues established by its Organic Law.
+
+### Article 66
+
+Each ordinary period of sessions shall last as long as necessary to solve the affairs mentioned at the previous article. The first period cannot be extended beyond December 15 of the respective year, except on those years when according to Article 83, a new President of the Republic is going to be inaugurated. In such a case, sessions may be extended until December 31. The second period shall not be extended beyond April 30 of the respective year.
+
+In the case that both Houses cannot reach an agreement about the closing dates of the sessions, the President of the Republic shall resolve the dispute.
+
+### Article 67
+
+The Congress or just one of the Houses, when dealing with an issue under its exclusive jurisdiction, shall assemble in extraordinary period of sessions at the Permanent Committee’s request. In such case, the Congress shall only resolve the issue or issues submitted by the Permanent Committee and indicated in the notification.
+
+### Article 68
+
+Both Houses shall be located at the same place and shall not be moved to a different one without a previous agreement on moving, period and procedure, but both Houses must reside in the same site. If no agreement is reached on the transfer’s duration, procedures and place, the President of the Republic resolves the issue by choosing one of the alternatives. No House shall adjourn sessions for more than three days without the explicit consent from the other one.
+
+### Article 69
+
+Every year, at the opening of the first ordinary period of sessions, the President of the Republic shall provide a written report, indicating the state of the country’s public administration. At the opening of an extraordinary period of sessions of the Congress, or only of one of the Houses, the Speaker of the Permanent Committee shall inform about the reasons leading to such extraordinary period of sessions.
+
+Each of the Houses shall analyze the report and can request the President of the Republic to expand on the information through written questions. The Houses can summon the Secretaries of State and the chairmen of the decentralized entities, who shall appear before the Congress to report under oath to tell the truth. The law and regulations of the Congress shall rule this attribution.
+
+During the first year of his term in office and in the opening ceremony of the second period of ordinary sessions, the President shall present before the Senate the National Strategy for Public Safety for its approval and shall present an annual report about its status.
+
+### Article 70
+
+Every resolution of the Congress shall have force of law or decree. Laws and decrees shall be communicated to the President of the Republic by a document signed by the Speakers of both Houses and by a Secretary of each one of them. Laws and decrees shall be enacted as follows: “The Congress of the United Mexican States decrees: (text of the respective law or decree)”.
+
+The Congress shall issue a law that will regulate its own structure and internal functioning.
+
+Such law shall specify the ways and procedures allowing associations of representatives to be formed according to their party affiliation in order to protect the freedom of speech of all ideological trends represented at the House of Representatives.
+
+Such a law shall never be vetoed nor require to be enacted by the President of the Republic in order to enter into force.
+
+### Section II. Bills and Laws Enactment
+
+### Article 71
+
+The ones who have the right to propose laws or decrees are:
+
+1. The President of the Republic.
+2. The House Representatives and Senators of the National Congress
+3. The State Legislatures
+4. The citizens in an equivalent number of, at least, zero point thirteen percent of the voters registration list, according to the terms set by the law.
+
+The Law of the Congress will determine the procedure for the initiatives.
+
+The opening day of each ordinary session period, the President of the Republic may present up to two initiatives for preferential procedure, or under such character appoint up to two initiatives that had already been presented in previous periods, when ruling pending. Each initiative should be discussed and voted by the Plenary of the Chamber of origin on a maximum of thirty natural days. Otherwise, the initiative under its terms and without any further procedures will be the first matter that will be discussed and voted in the next plenary session. If approved or modified by the originating Chamber, the respective bill of law or decree will immediately be passed to the reviewing Chamber for discussion and vote on the same period and under the mentioned conditions.
+
+The addition or reform initiatives of this Constitution will not have a preferential character.
+
+### Article 72
+
+Every single bill or decree shall be discussed successively at both Houses, except the issues that are within the exclusive jurisdiction of one of the Houses. The House shall observe the methods, periods of time and debating and voting procedures established by the Congress Act and its regulations.
+
+1. After being approved by one of the Houses, every bill shall be submitted to the other one in order to be discussed there. If the second House approves it, the bill shall be submitted to the President of the Republic who, after deciding that no further corrections should be made, shall publish it without delay.
+2. A bill forwarded to the President of the Republic which is not returned by him with his objections to the House where it was originated within 30 calendar days of the receipt, shall be deemed approved. After such term, the President of the Republic shall pass and publish the law or decree in the following 10 calendar days. After this second term, the law or decree shall be deemed enacted; then, in the following 10 calendar days, the President of the House, where the bill was originated, shall order publication of the law or decree in the Official Gazette of the Federation, without requiring endorsement. These deadlines shall not be suspended if the Congress closes or adjourns its sessions. In this case, the President of the Republic shall return the bill to the Permanent Committee.
+3. Any bill rejected partially or totally by the President of the Republic shall be returned with the respective corrections to the original House. The bill shall be discussed again in such House and, if confirmed by a two-thirds majority of votes, it shall be submitted again to the reviewer House. If a two-thirds majority of votes supports the bill at the second House, it shall be considered as enacted law or decree and shall be sent to the President of the Republic in order to be published.
+	Voting for enacting laws or decrees shall be nominal.
+4. If any bill is rejected in whole by the reviewing House, it shall be returned to the House where it was originated with the appropriate objections. The bill shall be again discussed in said House and, if approved by the absolute majority of its members present, it shall return to the House that rejected it, which shall analyze it again. If the second House approves the bill by the same majority, it shall be submitted to the President of the Republic, who has to comply with the purposes of paragraph “a”. If the second House does not approve the bill, it shall not be reintroduced in the same period of sessions.
+5. When any bill is partially rejected, modified or added by the reviewing House, the new discussion in the original House shall be focused on the rejected, reformed or added parts, leaving the already approved articles unchanged. If the additions or reforms made by the reviewing House are approved by absolute majority in the original House, the whole bill shall be submitted to the President of the Republic, who has to observe the provisions established in paragraph “a”. If the additions or reforms made by the reviewing House are rejected by majority of the members attending the original House, the bill shall be returned to the reviewing House, which shall study the reasons of the first House. If those additions or reforms are rejected again after a second review, the part of the bill approved by both Houses shall be sent to the President of the Republic, who has to observe the provisions established in paragraph “a”. If the absolute majority of the attending members at the reviewing Hose insists on enacting the additions and reforms, the whole bill shall be postponed until a the new period of sessions, unless the absolute majority of attending congressmen at both Houses agrees on enacting only the approved articles of the bill and on submitting additions or reforms to the next period of sessions.
+6. Regarding interpretation, reforms and repeal of laws or decrees, the same formalities established for enacting them shall be observed.
+7. Any bill rejected in the first House shall not be reintroduced in other period of sessions corresponding to the same year.
+8. Either of the two Houses can propose a law or decree first, except for bills about debenture loans, taxes or conscription, which shall be discussed first at the House of Representatives.
+9. The initiatives or bills shall be first discussed preferably in the House they were presented, unless the Consultative Commission of the first House delays to present an opinion about the bill for more than one month, then the bill can be submitted to the other House for discussion.
+10. The President of the Republic cannot make comments on the resolutions of the Congress or any of the Houses when act as electoral body or judge, as well as when the House of Representatives charges a top-ranking official with official offences.
+	The President of the Republic cannot make comments on the decree of call for extraordinary period of sessions issued by the Permanent Committee.
+
+### Section III. Powers of Congress
+
+### Article 73
+
+The Congress shall have the power to:
+
+1. Admit new states into the Union.
+2. (Repealed by the decree published on October 8, 1974)
+3. Create new states within the limits of the existing ones. For this purpose, the following requirements must be met:
+	1. The fraction or fractions that intend to become a new state must have at least one hundred and twenty thousand inhabitants.
+		2. The fraction or fractions that intend to become a new state shall substantiate before Congress that it possess enough elements to assure the new state’s political existence.
+		3. The legislatures of the states involved shall submit a report to the Congress, within the six months after notification was sent to them, about usefulness or inappropriateness of creation of the new state.
+		4. The President of the Republic must submit a report to the Congress within the seven days after notification about usefulness or inappropriateness of creation of the new state.
+		5. Proposal of creation of the new state shall obtain the two-thirds of the votes in each House.
+		6. The ruling pronounced by the Congress shall be ratified by majority of the state legislatures after reviewing of the file, provided that legislatures of the affected states have approved such ruling.
+		7. In the event that legislatures of the affected states do not consent creation of a new state, then ratification mentioned in the previous paragraph shall be done by two-thirds of the legislatures of the rest of the states.
+4. (Repealed by the decree published on December 8, 2005)
+5. Move the residence of the Federal Branches.
+6. (Repealed by the decree published on August 22, 1996)
+7. Lay and collect taxes in order to fund the national budget.
+8. In regard to public debt, to:
+	1. Establish the basis for the President of the Republic to celebrate loans and grant guarantees based on the country’s credit, to approve such debenture loans, to accept the foreign debt and to order payment of such foreign debt. Only credits producing an increase in public revenue shall be contracted or, according to the respective law, those acquired for monetary regulation purposes, for debt restructuration or refinancing. These last credits shall be guided by the principle of the best market conditions, as well as those acquired to face an emergency situation stated by the President of the Republic according to the Article 29.
+		2. The Congress shall also have the power to annually approve debt amount that in each case requires the Government of the Federal District and the government agencies, these debt amount shall be included in the Revenue Law according to the applicable law. The President of the Republic shall submit to the Congress an annual report about the spending of the debt. For this purpose, the Federal District Mayor shall submit to the President a report about the use of that debt corresponding to the Federal District. The Federal District Mayor shall also inform the Federal District Assembly about such spending together with the general report of the public administration.
+		3. The Congress shall establish the general basis about the loan agreements, the loan limits and the schemes of debt that the States, the Federal District and the Municipalities could acquire as well as the mechanisms that allow them to modify their participations and budgets to cover the corresponding payments. The States, the Federal District and the Municipalities must register and publish the total amount of debt and the payment schemes in the unique public registry in a timely and transparent manner. The Congress shall also establish an alert system about the debt management and the applicable sanctions to public officers that do not comply with these dispositions. These laws shall first be discussed at the House of Representatives according to the Article 72 section H of this Constitution.
+		4. The Congress, through the legislative commission of both Houses, shall analyze the strategies to strengthen the local public finances described in the agreements that the local governments promote with the Federal Government to obtain loans. The Congress may issue recommendations and observations within fifteen-business days limit, even in the recess periods of the Congress. The previous statement shall apply in the cases of those Local Governments that already have high levels of public debt according to the corresponding law. Immediately after the celebration of the agreement, the strategy to adjust the finances of the Municipalities that fall into the same case shall be informed. These may also apply for the agreements that the States celebrate regardless their debt level.
+9. To prevent restrictions to State-to-State commerce.
+10. To legislate Nation-wide on hydrocarbons, mining, chemical substances, explosives, pyrotechnics, movie industry, commerce, bets, draw and raffles, intermediation and financial services, electrical and nuclear energy, and to issue the regulations according to the article 123 of this Constitution.
+11. Create and cut public jobs in federal government, as well as to establish, increase or decrease salaries for such jobs.
+12. Declare war, based on the information submitted by the President of the Republic.
+13. Enact laws that assess quality of maritime and land dams, and the maritime legislation that shall be applied at both, peacetime and wartime.
+14. Support and maintain the country’s armed forces: the Army, the Navy and the Air Force. The Congress shall have the power to regulate organization and service of these armed forces.
+15. Make rules and regulations that organize, arm and discipline the National Guard. However, citizens participating in the National Guard shall appoint its chiefs and officers, and the states shall train its own National Guard.
+16. Enact laws on nationality, legal status of foreigners, citizenship, naturalization, colonization, immigration and public health:
+	1. The General Board of Health shall report directly to the President of the Republic, without intervention of any Ministry. Its orders and provisions issued by the General Board of Health shall be compulsory for the whole country.
+		2. In the event of serious epidemic or risk of invasion of exotic diseases, the Ministry of Public Health shall issue immediately the appropriate preventive measures, which may be approved by the President of the Republic.
+		3. The Sanitation Authority \[Ministry of Public Health\] shall be an executive organ; its orders, regulations, measures and provisions shall be observed by the administrative authorities throughout the country.
+		4. Measures issued by the General Board of Health for campaigns against alcoholism, drugs and pollution shall be reviewed by the Mexican Congress if applicable.
+17. Enact laws on means of communication, information technology and communication, broadcasting, telecommunication, including broadband and Internet, posts and mail, and the use and enjoyment of federal jurisdiction waters.
+18. Establish the treasury \[mints\] and regulate them, to make rules to determine exchange rate, and to adopt a general system of weights and measures.
+19. Regulate occupation and alienation of wasteland and the price thereof.
+20. Enact laws to regulate the Mexican diplomatic and consular corps.
+21. Issue:
+	1. General laws that establish, at a minimum, types of criminal offenses and its respective sentencing parameters in regard to kidnapping, enforced disappearances, others types of illegal restrictions to freedom, human trafficking, torture, and other cruel or dehumanizing treatments, as well as electoral crimes.
+		General laws shall also regulate the distribution of competences and the way to coordinate efforts among the Federation, the States, the Federal District and the Municipalities;
+		2. Legislation to determine felonies and misdemeanors against the Federation, their sentencing parameters and sanctions to be imposed, as well as legislation in regard to organized crime;
+		3. Unified legislation to regulate criminal procedure, alternative dispute resolution, sentencing execution and teenagers’ criminal justice at the federal or ordinary jurisdiction.
+	Federal authorities may hear cases involving ordinary felonies when said cases are connected to cases involving federal felonies, or felonies against journalists, people or infrastructure that affect, limit or abridge the right of access to information, freedom of speech or freedom of press.
+	In those areas of concurrent jurisdiction set forth in this Constitution, federal laws shall determine the cases in which ordinary courts may hear and decide cases involving federal felonies;
+22. Grant an amnesty for federal crimes.
+23. Enact laws to regulate coordination between the Federal Government, the Federal District, the States and the Municipalities, as well as to create and organize federal public security bodies, according to the Article 21 of this Constitution
+24. Enact the laws that organize and establish the powers of the Federal Auditing Office and those laws that regulate the management, control and evaluation of the Powers of the Union, the federal agencies, as well as to enact the general law that establishes the basis for the coordination of the National Anticorruption System according to the article 113 of this Constitution.
+25. To establish the Teaching Professional Service in terms of article 3rd of this Constitution; to establish, organize and fund, throughout the Republic, rural, elementary, junior high, high and professional schools for scientific research, fine arts and technical studies, practical agriculture and mining schools, arts and crafts school, museums, libraries, observatories and other institutions related to the general culture of the nations’ inhabitants and to legislate in the fields related to these institutions; to legislate on traces and fossil remains and on archeological, artistic and historical monuments, which preservation be deemed as of national interest; as well as to pass laws oriented to conveniently allocate among the Federation, the States and Municipalities the exercise of the educational function and economic contributions corresponding to that public service, aiming to unify and coordinate education throughout the Republic, and to ensure the fulfillment of educational purposes and their continued improvement, in a framework of inclusion and diversity. Degrees issued by these establishments shall be recognized throughout the Republic. To legislate on copyright and other issues of intellectual property issues related to the same.
+26. To grant a leave to the President of the Republic and to constitute itself into an Electoral College in order to appoint the citizen that should substitute the President of the Republic either as interim or alternate, under the terms of articles 84 and 85 of this Constitution.
+27. Accept the President of the Republic’s resignation.
+28. Enact laws to regulate public accounts, the submission of financial reports and reports on revenues and expenditures, as well as patrimony reports, which shall apply to the federal government, the States, the Federal District, the Municipalities and all the political-administrative organs that correspond aiming for a homogeneous and harmonized procedures for public accounts.
+29. To lay and collect taxes on the following items:
+	1. Foreign trade
+		2. The use and exploitation of natural resources mentioned in the Article 27, paragraphs 4 and 5
+		3. Credit institutions and insurance companies
+		4. Public services either provided by concessionaires or by the government
+		5. The Congress shall have the power to lay and collect special taxes on:
+		1. Electrical energy
+				2. Production and consumption of carved tobacco
+				3. Gasoline and other products derived from oil
+				4. Matches
+				5. Maguey juice and its products.
+				6. Forest exploitation
+				7. Production and consumption of beer
+		The states shall receive, under federal legislation, a percentage of the revenue generated by the special taxes. Local legislatures shall set the percentage corresponding to municipalities, in their income from tax over electric power service.
+30. Regulate characteristics and use of the national flag, anthem and coat of arms.
+31. To regulate coordination between the Federal Government, the states and the municipalities to order human settlements, complying this way with the goals established the Article 27, in paragraph 3, of this Constitution.
+32. Enact laws regarding national economic and social planning, as well as statistical and geographical information.
+33. Enact laws for programming, promotion, covenants and implementation of economic measures, especially those related to supply, as well as those intended to achieve adequate and timely production of goods and services, considered as socially necessary.
+34. Enact laws: a) to promote Mexican investment; b) to regulate foreign investment and transfer of technology; and c) to regulate generation, spreading and implementation of scientific and technological knowledge necessary for the country’s development.
+35. Enact laws establishing the concurrence of the Federal Government, the states and the municipalities, within their respective jurisdictions, on matters concerning protection of the environment, as well as preservation and restoration of ecological balance.
+36. To legislate for the creation of completely autonomous Federal Administrative Tribunal empowered to resolve the legal controversies between the federal public administration and individuals. Administrative courts shall impose penalties on public employees originated by administrative liabilities that the law considers as severe felonies and to the individuals that participate in those acts, as well as to set the compensations and economic sanctions for the damages to the Public Treasury or the estate of the public agencies.
+	The Administrative Court shall be organized by plenary meetings or regional courts.
+	The Superior Court of the Administrative Tribunal will have sixteen judges and shall perform in plenary meetings or by sections. One of these sections will be in charge of the resolutions regarding the third paragraph of this article.
+	The judges of the Superior Court shall be appointed by the President and ratified by the votes of two-thirds of the present members of the Senate or the Permanent Committee if the Senate is in recess. The judges shall be appointed for fifteen years without possibility of remaining in office.
+	The judges of the Regional Courts shall be appointed by the President and ratified by the majority vote of the present members of the Senate or the Permanent Committee if the Senate is in recess. The judges shall be appointed for ten years and may be considered for a new term in office.
+	The judges may only be removed form office due to serious grounds stated by the law.
+37. Enact laws that coordinate the measures implemented by the federal government, the states, the Federal District and the municipalities regarding civil protection matter.
+38. To legislate in regard to physical culture and sports with the purpose of complying with that which is outlined in article 4 of this Constitution, establishing the concurrence between the Federation, the states, the Federal District and the municipalities, as well as the participation of social and private sectors.
+39. Legislate on matters concerning tourism, establishing general bases to coordinate the concurrent attributions of the Federal Government, the states, the Federal District and the municipalities; as well as the participation of the private and social sectors.
+40. Legislate on matters concerning fishing and aquaculture, establishing general bases to coordinate the concurrent attributions of the Federal Government, the states, the Federal District and the municipalities; as well as the participation of the private and social sectors.
+41. Enact laws in matters of national security, establishing the requirements and limits to the corresponding investigations.
+42. Issue laws regarding the formation, organization, functioning and suppression of cooperatives. These laws shall establish the bases to coordinate the concurrent attributions of the Federal Government, the states, the Federal District and the municipalities regarding promotion and sustainable development of cooperatives.
+43. Legislate on matters concerning culture, establishing general bases to coordinate the concurrent attributions of the Federal Government, the states, the Federal District and the municipalities, except by that established in the section XXV of this article. This law shall also define the mechanisms through which social and private sectors shall participate, complying this way with the goals indicated in the Article 4, paragraph ninth, of this Constitution.
+44. Regulate the use and protect personal data handled by private entities.
+45. To emit laws that establish the concurrence of the Federation, the states, the Federal District and the municipalities, in their respective competencies, on the subject of the rights of girls, boys and adolescents, safeguarding, at all times, their best interest and complying with international agreements that Mexico may be a part of on this subject.
+46. To legislate over citizens’ initiatives and referendums
+47. To issue a general law to harmonize and homologue the organization and operation of the real estate and legal entities public registries of the federative entities and municipal cadastral authorities.
+48. To issue general regulating laws that establish the principles and basis in regard to government transparency, access to information and protection of personal data held by authorities, entities or government agencies at all levels of government.
+49. To issue a general law that establishes a homogenous and coordinated system to organize and manage all the files and documents at the federal, local and municipal level including the Federal District and its political subdivisions. This law must describe the organization and functions of the National Archives System.
+50. To issue the general laws that allocates the competences between the federation and the federative entities in regard to the political parties, electoral organs and electoral processes according to the specifications of this Constitution.
+51. To issue the general law that allocates the competences between the Federal, Local and Municipal governments to establish the administrative responsibilities to public servants, their obligations and applicable sanctions for the acts and omissions that infringe the law and that relates to the public servants to serious administrative faults, as well as the procedures for the application of these sanctions.
+52. To issue laws in regard to fiscal responsibility that have the purpose of a sustainable management of public finance at the Federal, Local and Municipal levels including the Federal District, according to the principles established in the second paragraph of the Article 25th of this Constitution.
+53. Enact all laws required to make effective the foregoing powers and any other powers vested by this Constitution on the Powers of the Union.
+
+### Article 74
+
+The Constitution grants the House of Representatives several exclusive powers:
+
+1. The power to issue the Solemn Edict in order to inform the whole country that the Electoral Court of the Judicial Power has issued a declaration stating that the President of the Republic has been elected.
+2. The power to coordinate and evaluate the performance of the Federal Auditing Office, according to the law and without damage to its own technical and managerial autonomy.
+3. To ratify the appointment made by the President to the Secretary of the Treasury, unless when a coalition government was formed, in which case would be under the specifications of the article 76 fraction II of this Constitution, as well as the directive employees at the Secretary of the Treasure.
+4. The power to annually approve the Nation’s budget, after assessment, discussion and, if applicable, modification of the project submitted by the President of the Republic; and after approval of taxes and contributions to cover such budget. The House of Representatives shall have the exclusive power to authorize multiannual expenditures for construction of infrastructure, so subsequent budgets shall include these multiannual expenditures.
+	The President of the Republic shall submit to the House of Representatives his proposal of the Income Act and the Expenditure Budget no later than September 8 and the pertinent Secretary shall appear before the House in order to clarify the accounts. The House of Representative shall approve the Budget no later than November 15.
+	When the President of the Republic begins his term on the date stated by the Article 83, he shall submit to the House of Representatives his proposal of the Income Act and the Expenditure Budget no later than November 15.
+	Only the absolutely necessary secret items may be included in the Expenditure Budget. The Secretaries shall use such secret items under written consent of the President of the Republic.
+	The President of the Republic can request an extension to submit his proposal of the Income Act and the Expenditure Budget, justifying the causes to the House of Representatives. The pertinent Secretary shall appear before the House to inform about the reasons for extension.
+5. The power to approve or object to criminal proceedings against public servants who have committed an offense according to the Article 111 of this Constitution.
+	The House of Representatives shall be notified about the charges against public employees mentioned in the Article 110 of this Constitution. The House shall have the power to become an accusing organ in impeachments against civil servants.
+6. The power to review the public accounts corresponding to the previous year, in order to assess the results thereof, to check observance of the criteria stated in the approved budget, and to verify achievement of the objectives indicated in the several programs.
+	The House of Representatives shall review the public accounts through the Federal Auditing Office. If this office finds out discrepancies related to revenues or expenditures, or if it finds out inaccuracy or unjustified revenues or expenditures, the law shall be applied to punish misconduct. Regarding achievement of the objectives stated in the several programs, the House can only issue a recommendation in accordance to the law.
+	Public account shall be submitted to the House of Representative no later than April 30 of the next year. This term may be extended only in the case mentioned in paragraph IV, last rows, of this Article. Extension shall not exceed 30 days. In such case, the Federal Auditing Office shall have the same extension to present the respective report.
+	The Chamber will complete the review of the Public Account, the latest, on October 31 of the following year after presentation, based on the analysis of the content and technical conclusions of the result report of the Federal Auditing Office, referred in Article 79 of this Constitution, recognizing that the observation procedures, recommendation and actions filed by the Federal Auditing Office will continue under the terms provided in such article.
+	The Chamber of Deputies will evaluate the performance of the Federal Auditing Office and may require a report about the progress of auditing works.
+7. Approve the National Development Plan within the time limit established by law. In case that the House of Representatives does not decide about the plan within the time period it would be considered as approved.
+8. Appoint, by the vote of two-thirds of its present members, the heads of the internal control organs of those entities granted with autonomy by this Constitution and that use public resources stated in the Federal Budget.
+9. Other exclusive powers conferred by this Constitution.
+
+### Article 75
+
+The House of Representatives shall indicate, in the Expenditure Budget, the wages for all public employments created under the law. In the event that the House fails to indicate such wages, the wages established in the previous Budget or in the law that created the job shall be in force.
+
+Nonetheless, remuneration shall be established observing the provisions of the Article 127 of this Constitution and the applicable laws.
+
+The federal executive, legislative and judicial branches, as well as autonomous bodies recognized in this Constitution, and which use public resources from the Federal Budget, shall include in their project budgets detailed tables of remunerations proposed for their public servants. Such project budgets shall observe the procedure for approval of budget expenditures provided in the Article 74, paragraph IV of this Constitution and other applicable laws.
+
+### Article 76
+
+The Constitution grants the Senate several exclusive powers:
+
+1. Power to analyze the foreign policy developed by the President of the Republic, based on the annual reports submitted to the Senate by the President and the Secretary of Foreign Affairs.
+	The Senate shall have the power to approve the international treaties and conventions subscribed by the President of the Republic, as well as his decision to end, condemn, suspend, modify, amend, withdraw reservations and make interpretative declarations related such treaties and conventions;
+2. Ratify appointments made by the President of the Secretaries of State in case that a government coalition is formed, with exception of the Secretaries of National Defense and the Navy; the Secretary responsible for internal control of the Federal Executive; the Foreign Affairs Minister; the Ambassadors and General Consuls; the directive employees of the Foreign Affairs Ministry; the members of the collegiate organs in charge of the regulation in regard to telecommunications, energy, economic competitiveness, colonels and other high ranking members of the Army, Navy and Air Force, according to the terms that the law establishes;
+3. Power to authorize the President of the Republic to allow departure of Mexican troops outside the country, passing of foreign troops through the country and stay of foreign troops for more than one month on Mexican waters.
+4. Power to authorize the President of the Republic to dispose the National Guard outside its respective states, and to determine the necessary forces.
+5. In the event that all constitutional powers of one state disappear, the Senate shall have the power to appoint a provisional governor, who shall call elections according to the Constitution of the state in question. The President of the Republic shall propose three candidates to become provisional governor. The two-thirds of the present Senators or, given a recess, the Permanent Committee shall approve one of the candidates. The provisional governor cannot be nominated as constitutional governor in the elections called by him. This provision shall govern whenever the constitutions of the states do not provide otherwise.
+6. Power to resolve the political disputes that arise between the powers of a state when one of the parties submits the case to the Senate, or in the event that such disputes have generated an armed conflict. In such a case, the Senate will pronounce a resolution based on the Federal Constitution and the constitution of the state in question.
+	Law shall regulate the exercise of the two previous powers.
+7. Power to become ruling jury in the impeachments against public servants in the cases of faults or omissions that damage the public interest, according to the Article 110 of this Constitution;
+8. Power to appoint the Justices of the Supreme Court of Justice of the Nation among the three candidates proposed by the President of the Republic. The Senate has the power to approve or reject leaves or resignations of Supreme Court Justices.
+9. Power to appoint and dismiss the Head of the Federal District Government, in the cases provided by this Constitution.
+10. Power to authorize amicable covenants made by the states regarding their borders. Such covenants shall be authorized by the two-thirds of the members present in Senate.
+11. To approve the National Public Safety Strategy within the time limit that the law provides, if the Senate does not decide in the time limit the strategy will be considered as approved.
+12. Appoint the commissioners of the National Transparency Agency \[organo garante\] that the Article 6th of this Constitution establishes, in the terms established by the Constitution and by the provisions provided by the law.
+13. To provide a list of candidates to be nominated as Federal Attorney General, appoint that public servant and present an objection if the President asks for the removal of the Federal Attorney General according to the Part A of the 102nd Article of this Constitution.
+14. Other exclusive powers conferred by this Constitution
+
+### Article 77
+
+Each of the Houses may, without the intervention of the other one:
+
+1. Pronounce resolutions regarding its internal economic affairs.
+2. Communicate with the other House and with the President of the Republic through internal committees.
+3. Appoint the employees for its own secretary’s office and issue regulations for it.
+4. In the event of a vacancy of a seat awarded according to the principle of majority voting, the House in question shall call to extraordinary elections within the 30 days after the vacancy appears. Elections shall be carried out within the 90 days after the call (see Article 63 of this Constitution). Except in the case the vacancy occurs in the last year of the term.
+
+### Section IV. Permanent Committee
+
+### Article 78
+
+During recesses of the Congress of the Union, there shall be a Permanent Committee composed of 37 members; 19 shall be Representatives and 18 shall be Senators, appointed by their respective House the day before the closing of the ordinary period of sessions. A substitute shall be appointed for each member of the Permanent Committee.
+
+Besides the powers conferred by this Constitution, the Permanent Committee shall have the following powers:
+
+1. To consent the use of National Guard in the cases described in the Article 76, paragraph IV.
+2. To receive the President of the Republic’s oath, if applicable.
+3. To resolve issues within its jurisdiction. To receive bills, comments to the bills made by the President of the Republic, and proposals, as well as to dispatch them to the appropriate commission to be resolved in the next ordinary period of sessions.
+4. Agree by its own means or by proposal of the Executive the call for an extraordinary period of sessions in one or both Houses of the Congress. The call shall be approved the vote for two-thirds of the present congressmen/congresswomen. The call shall clearly state the reasons and objectives for the extraordinary sessions. When the reason for the extraordinary call is because the General Congress needs to become an Electoral College to appoint the interim or alternate president, the approval for the call shall only require the votes of the majority of the present members.
+5. (Removed by the decree published on February 10, 2014)
+6. Granting a leave for up to sixty natural days to the President of the Republic.
+7. Ratify appointments made by the President to ambassadors, general consuls, high-ranking officers of the Treasury, members of the collegiate bodies in charge of regulating energy matters, colonels and other chiefs of the National Army, Navy and Air Forces, according to the terms set by the law;
+8. To receive and resolve requests of leaves submitted by congressmen/congresswomen.
+
+### Section V. The Federal Auditing Office
+
+### Article 79
+
+The Federal Auditing Office, which belongs to the House of Representatives, shall have autonomy regarding technical and managerial matters, as well as regarding its internal organization, functioning and decisions, according to the law.
+
+Auditing function shall be exercised according to the principles of legality, definitiveness, impartiality and reliability.
+
+The Federal Auditing Office shall begin with the auditing process on the first working day of the of the next fiscal year regardless that the observations or recommendations that in the case result shall refer to the definitive information presented in the Public Account.
+
+In regard to the planning of the auditing procedures, the Federal Auditing Office shall request the information of the current fiscal year in regard to the finished processes.
+
+The Federal Auditing Office shall be responsible for:
+
+1. Auditing, in a posterior manner, the revenues, expenditures, debts; the loans that in the case the Federal Government grants to local and municipal governments; the management, the safekeeping and use of funds and resources belonging to the Powers of the Union and to the federal agencies. The Federal Auditing Office shall audit, as well, the fulfillment of the objectives included in the several federal programs, using the reports submitted according to the law.
+	The Federal Auditing Office shall also supervise directly the management or use of federal resources made by the States, Municipalities, the Federal District and the political-administrative organs within their territories, except by federal contributions. In case the States and Municipalities have loans granted by the Federal Government, the Federal Auditing Office shall oversee the management and use of the corresponding resources. This Office will also supervise the use of federal resources granted to any public or private entity or individual, those transferred to trusts, mandates, funds or any other legal instrument, in accordance with the procedures established by law and without damage to other authorities’ jurisdiction and to the users’ rights.
+	Entities that are subjected to fiscal supervision according to the previous paragraph, shall accurately do and register their accounts, report the use of federal patrimony and detail the use of the budget transferred to them, in accordance with the criteria established by law.
+	Despite the principle of annuity, the Federal Auditing Office can request and review concrete information of previous years to that of the public account being revised, this faculty does not mean that the public account of that year has been opened again. The request for information may only be reopened when the program covers more than one year or when fulfillment of objectives is under revision. However, comments and recommendations issued by the Federal Auditing Office shall only refer to the public account belonging to the year under revision.
+	Regardless of the provisions in the previous paragraphs, the Federal Auditing Office, pervious authorization of its chief officer, may review government agencies during the current fiscal years or their information for past fiscal years in the situations described by the law and as consequences of accusations or lawsuits. The government agencies shall give the information requested by the Federal Auditing Office within the time limits considered by the law, if the entity does not meet the deadline and formalities, it shall be punished according to the law. The Federal Auditing Office shall submit a report about the case to the House of Representatives and, if applicable, it shall fix responsibilities or initiate responsibilities before the Administrative Courts, the Anti-Corruption Prosecution Office or the appropriate authority.
+2. The Federal Auditing Office shall submit to the House of Representatives the individual auditing reports of public account of the respective fiscal year that they have concluded on the last working day of the months of June and October, as well as February 20 of the next year. On this same date the Fiscal Auditing Office shall submit the General Executive Report of the Public Accounts Audit, which shall be considered by the floor of the House of Representatives. This report shall be public and shall include audits, opinions, justifications and observations that the government agencies have presented.
+	For this purpose, before the submission of the general executive report and the individual reports to the House of Representatives, the Federal Auditing Office shall notify the entities under revision about the results obtained from their public accounts, so that they could submit the pertinent justifications and explanations.
+	The Head of the Federal Auditing Office shall send to the entities under revision the individual reports with recommendations and measures suggested no later than 10 business days after submission of the report to the House of Representatives. The entities under revision shall, within 30 business days, present the appropriate information and carry out the suitable measures. The law shall establish punishments for failures thereof. This provision shall not apply to the lists of accusations, which shall observe the procedures and terms established by law.
+	The Federal Auditing Office shall, within a 120 business days term, answer the explanations and justifications submitted by the entities under revision. Failure to do so means that explanations and justifications have been accepted.
+	Regarding fulfillment of recommendations, the entities under revision shall describe the improvements carried out or justify the inappropriateness of the measures suggested by the Federal Auditing Office.
+	On May 1 and November 1 of every year, the Federal Auditing Office shall submit to the House of Representatives a report about the progress of recommendations and measures suggested to the public entities in the individual reports. This report shall be public and the Federal Auditing Office shall describe the amounts that the Federal Treasury have received or the amounts that have been restore to the estate of the Government Agencies as consequence of their audits or legal procedures presented before Administrative Courts.
+	The Federal Auditing Office shall keep on reserve its acts and comments until the general report and the individual reports have been submitted to the House of Representatives. The law shall establish appropriate punishments for offenders thereof.
+3. Investigation of actions or omissions related to irregularities or illicit conducts about income, expenditures, management, safekeeping and use of funds and federal resources. The Federal Auditing Office can make home visits only to review the books, documents and files necessary for the investigation, in accordance to the law and formalities.
+4. As a result of its investigations, the Federal Auditing Office shall establish the damages and losses affecting the public finances or public assets in order to set the responsibilities and liability actions before the Administrative Courts and the Anti-corruption Prosecution Office of the responsible federal public servants and according to the second paragraph of the first item in this article to the responsible public servants of the states, the Federal District and the municipalities.
+
+The Head of the Federal Auditing Office shall be appointed by the two-thirds of the members present in the House of Representatives, in accordance with the procedure established for this purpose. The head of the Federal Auditing Office is appointed to serve for a period of eight years and may be appointed again once only. He may be removed, exclusively for serious misdemeanor described in the law, by the vote of two-thirds of the members present in the House of Representatives. He may be also removed due to the causes established in the Title Four of this Constitution.
+
+To qualify for the position of Head of the Federal Auditing Office, it is necessary to fill the requirements established in paragraphs I, II, IV, V and VI of the Article 95 of this Constitution, as well as the other requirements established by the law. While holding the office, the Head of the Federal Auditing Office cannot join any political party nor perform any other job, position or assignment, except for unpaid services in scientific, educational, cultural or altruistic institutions.
+
+The different Powers of the Union, the states and the government agencies subjected to revision shall assist the Federal Auditing Office in carrying out its work. This provision applies also to federal and local employees, as well as to any private or public entity, trust, mandate or fund that uses public federal resources. This provision does not damage the jurisdiction of other authorities nor the user’s rights of the banking system. Refusal to assist the Federal Auditing Office with the information required shall be punished according to the law.
+
+The president of the Republic shall apply an administrative proceeding to enforce payment of compensations and pecuniary penalties defined in the paragraph IV of this article.
+
+### CHAPTER III. The Federal Executive Branch
+
+### Article 80
+
+The power of the Executive Branch is vested in one single person, the President of the United Mexican States.
+
+### Article 81
+
+The President of the United Mexican States is directly elected by the people according to the electoral law.
+
+### Article 82
+
+Qualifications for the Presidency:
+
+1. The candidate for the Presidency must be a natural born citizen, with legal capacity to exercise his rights, born of Mexican father or mother and must have live in the country for at least 20 years.
+2. The candidate for the Presidency must be 35 years of age on the election date.
+3. The candidate for the Presidency must have live in the country for a full year prior to the day of the election. Absences for up to 30 days do not interrupt residence.
+4. The candidate for the Presidency cannot be priest or minister of any religion.
+5. The candidate should not be in active duty in the Army at least six months before the day of the election.
+6. The candidate should not be Secretary of State or Under-Secretary, Federal Attorney General, Governor or Head of the Federal District Government, unless he resigns his position six months before the election date.
+7. To be unaffected by the inabilities established under the Article 83.
+
+### Article 83
+
+The President will begin his tenure on October 1st and will last six years in office. The citizen who had performed as President of the Republic, popularly elected or under the interim or alternate character, or provisionally takes the office of the Federal Executive, in no case and under any circumstances may perform again this position.
+
+### Article 84
+
+In case of a complete absence of President of the Republic, while the Congress appoints the interim or alternate president in a term no longer than sixty days, the Minister of Interior will provisionally take the office of the Executive Power. In this case, sections II, III and VI of Article 82 of this Constitution will not be applicable.
+
+Whoever provisionally occupies the Presidency will not be able to withdraw or appoint State Secretaries without the previous authorization of the Chamber of Senators. Likewise, he will present to the Congress a work report in no longer than ten days period counted just after his commission ends.
+
+When there is complete absence of President during the two first years of the respective period, if the Congress of the Union were in sessions and at least two thirds of the total number of members of each Chamber were attending, the Congress shall immediately constitute itself in the Electoral College. The Electoral College through secret ballot and by the vote of the absolute majority shall appoint an interim president under the terms set by the Law of the Congress. The same Congress will issue, within ten days following such appointment, the call for the election of President that should end the respective period. Between the date of the call for elections and the Election Day there shall be no less than seven months and no more than nine months. The elected president will begin his/her term in office and swear before the Congress seven days after the electoral process has ended
+
+If the Congress were not in sessions, the Permanent Commission will immediately call for extraordinary sessions to constitute the Electoral College, appoint an interim president and issue the call to presidential elections under the terms of the previous paragraph.
+
+When the complete absence of President happens in the last four years of the respective period, if the Congress of the Union is in session, it will appoint an alternate president, who will complete the period, following in that capacity, the same procedure as in the case of the interim president.
+
+If the Congress were not in sessions, the Permanent Commission will immediate call for extraordinary sessions to constitute the Electoral College and to appoint an alternate president, following in that capacity, the same procedure as in the case of interim president.
+
+### Article 85
+
+If before starting a constitutional period the election was not made or declared as valid, the President whose office has ended will cease and the interim president will be appointed by the Congress under the terms of the above Article.
+
+If when starting a constitutional period there is a complete absence of President of the Republic, the position will be provisionally taken by the President of the Chamber of Senators, while the Congress appoints the interim president, in accordance to the above Article.
+
+When the President requests leave to separate from the office up to sixty natural days, once authorized by the Congress, the Minister of Interior will provisionally take the office of the Executive Power.
+
+If a temporary absence of the President becomes into an absolute absence, the Congress shall act as indicated in the previous article.
+
+### Article 86
+
+The President of the Republic can resign his position only due to a serious cause, which shall be evaluated by the Congress, to whom the resignation shall be submitted.
+
+### Article 87
+
+The President, upon taking office, takes the following oath before the Congress, or before the Permanent Committee during the recess of the Congress: “I swear to observe and uphold the Political Constitution of the United Mexican States and the laws that emanate from it, and to loyally and patriotically perform the position of President of the Republic, which the people have conferred upon me, pursuing the welfare and prosperity of the country; and if I do not fulfill these obligations, may the Nation demand it of me.”
+
+If by any circumstance the President could not take the oath under the terms of the above paragraph, he will do so immediately before the Executive Boards of the Chambers of the Congress of the Union.
+
+In case that the President could not swear in before the Congress of the Union, before the Permanent Commission or before the Executive Boards of the Chambers of the Congress of the Union, he will do so immediately before the President of the Supreme Court of Justice of the Nation.
+
+### Article 88
+
+The President of the Republic can leave the national territory for up to seven days, previously notifying his reasons to the Senate or the Permanent Committee, as applicable, as well as the outcome of his activities. For absences larger than seven days, the President shall request a permit from the Senate or the Permanent Committee.
+
+### Article 89
+
+The powers and rights of the President of the Republic are the following:
+
+1. To enact and execute the laws issued by the Congress of the Union providing in the administrative field its compliance.
+2. To freely appoint and remove the State Secretaries, to remove the ambassadors, general consuls and directive employees of the Treasury, and to freely appoint and remove the rest of the employees of the Union, whose appointment or removal is not otherwise set in the Constitution or laws;
+	The Secretaries of State and high-ranking employees of the Treasury and Foreign Affairs shall begin their functions on the date of their appointment, When they were not ratified in the terms established by this Constitution they will cease their functions.
+	According to the postulates about the ratification of the Foreign Affairs Minister and the Treasury Minister, when there is not a coalition government in functions, if the respective Chamber does not ratify in two occasions the appointment of the nominated Minister then the person selected by the Federal Executive shall occupy the office.
+3. To appoint, with approval from the Senate, the ambassadors, general consuls, executive employees of the Treasury, and the members of the collegiate bodies in charge of regulation in the matters of telecommunications, power and economic competence;
+4. To appoint, with approval from the Senate, Colonels and other chiefs of the National Army, Navy and Air Forces, according to the laws.
+5. To appoint, according to the law, the rest of the officers of the Army, Navy and Air Force.
+6. To protect national security, in accordance to the applicable law. For this purpose, the President of the Republic can make use of the permanent armed forces: the Army, the Navy and the Air Force for homeland security and defense of the federation against foreign threats.
+7. To make use of the National Guard to assure domestic security and to protect the nation from other nations, observing the provisions established in the Article 76, section IV.
+8. To declare war in the name of the United Mexican States, having the previous authorization of the Congress.
+9. To mediate in the appointment and removal of the Federal Attorney General, in the terms provided by the part A of the Article 102 of this Constitution.
+10. To lead the foreign policy; to make and execute international treaties; as well as to end, condemn, suspend, modify, amend, withdraw reservations and make interpretative declarations relating such treaties and conventions, requiring the authorization of the Senate. For these purposes, the President of the Republic shall observe the following principles: the right to self-determination; non-intervention; peaceful solution of controversies; outlawing the use of force or threat in international relations; equal rights of States; international cooperation for development; the respect, protection and promotion of human rights; and the struggle for international peace and security.
+11. To call the Congress to an extraordinary period of sessions at Permanent Committee’s agreement.
+12. To provide the Judicial Branch with all the assistance necessary for the prompt performance of its duties.
+13. To equip all kind of ports; to set up maritime and border customs, indicating the place to install them.
+14. To grant, according to the law, a pardon to the convicts sentenced because of federal crimes and to the convicts sentenced for common crimes committed in the Federal District.
+15. To grant exclusive privileges, for a limited period of time, to discoverers, inventors or improvers in any branch of industry, according to the applicable law.
+16. During the recess of the Senate, the President of the Republic can make the appointments mentioned in the paragraphs III, IV and IX, having the approval of the Permanent Committee.
+17. At any moment, to opt for a coalition government with one or several political parties represented at the Congress.
+	A covenant and a program shall regulate the government coalition; the majority of the present members of the Senate shall approve these programs and covenants. The covenant shall state the causes for the dissolution of the coalition.
+18. To submit to the Senate a list of candidates to become Justices of the Supreme Court of Justice; and to require authorization for their leaves and resignations to the Senate.
+19. Reject, under the terms described by the Constitution and the law, the appointments of the Commissioners of the National Transparency Agency \[Organo Garante\] issued by the Senate according to the 6th article of this Constitution.
+20. Other powers expressly conferred by this Constitution.
+
+### Article 90
+
+Federal Public Administration shall be centralized and semipublic, according to the organic law issued by the Congress, which shall allocate the federal administrative affairs among the Secretariats and shall set the general basis to create semipublic entities and the participation of the Federal Executive in their operation.
+
+The laws shall regulate the relations between semipublic entities and the President of the Republic or between them and the Secretariats.
+
+The functions of the Legal Counselor of the Government shall depend upon the office within the Federal Executive that the law establishes for that purpose.
+
+The Federal Executive will represent the Federation in any matters that it is a party through the office that holds the responsibility of Legal Counselor of the Government or through the Secretariats in the terms established by law.
+
+### Article 91
+
+In order to become a Secretary of State, it is required to be a Mexican citizen by birth, with legal capacity to exercise his rights, and to be 30 years old.
+
+### Article 92
+
+All regulations, decrees, covenants and orders issued by the President of the Republic shall also be signed by the Secretary of State in charge of the matter, otherwise they won’t be compulsory.
+
+### Article 93
+
+The Secretaries of State as soon as the ordinary period of sessions is open, shall answer to the Congress for the state of their respective affairs.
+
+Any of the Houses can call the Secretaries of State, the directors and managers of semipublic entities and the heads of autonomous agencies in order to provide more information, under oath, whenever the Congress is studying or discussing a law or affair related to their activities or areas of responsibility, or to answer any inquiry that the Congress have in regard to the matter.
+
+The House of Representatives, by request of a quarter of its members, and the Senate, by request of a half of its members, have the power to create committees to investigate the functioning of decentralized and semipublic entities. The results of the investigations shall be submitted to the President of the Republic.
+
+Any of the Houses can require, by a written inquiry, information or documents to the heads of the federal agencies, who shall answer the inquiry within the next 15 days after request was received.
+
+These attributions shall be exercised according to the Law and regulations of the Congress.
+
+### CHAPTER IV. The Judicial Branch
+
+### Article 94
+
+The judicial power of the United Mexican States is vested in a Supreme Court of Justice, an Electoral Court, specialized circuit courts, unitary circuit courts and the district courts.
+
+The Federal Judicial Council shall deal with matters of administration, supervision and discipline for Mexican federal judges, except for the Supreme Court of Justice of the Nation, according to the provisions established by law.
+
+The Supreme Court of Justice of the Nation shall consist of 11 Justices and shall work at plenary meetings or at courtrooms.
+
+Sessions in plenary meeting or in courtrooms shall be public, in accordance with the law. Sessions may be secret whenever public interest or public morality should so require it.
+
+The laws shall regulate, based on this Constitution, powers and functioning of the Supreme Court of Justice, the circuit courts, the district courts and the Electoral Court. The law shall establish liabilities for the Judicial Power’s employees.
+
+The Federal Judicial Council shall define the number, district division, territorial competence and subject matter specialization—including broadcasting, telecommunications and economic competition—of collegiate and unitary circuit courts, as well as of the district courts.
+
+Likewise, it shall have the power to issue general covenants in order to create circuit courts, according to the number and specialization of the collegiate courts that belong to each circuit. The laws shall regulate integration and operation of these circuit courts.
+
+The Supreme Court of Justice in plenary meeting shall have the power to issue general covenants in order to achieve an adequate distribution of issues among the courtrooms and to submit to the specialized circuit courts those cases where they shall have established precedents and those affairs selected by the Supreme Court in order to deal with the cases promptly. Said covenants shall come into force after being published.
+
+Constitutional adjudications \[amparo\], constitutional controversies and unconstitutionality claims shall have priority when one of the chambers of the Congress, through its Speaker, or the President of the Republic, through its Legal Councilor, justifies the urgency on the basis of social interest or the law and order, in accordance with the regulatory laws.
+
+The law shall define the cases where precedents established by the federal and circuit courts shall be compulsory, relating to interpretation of the Constitution and general laws, as well as the requirements for interruption and modification thereof.
+
+Remuneration granted to the Justices of the Supreme Court, the circuit judges, the district judges, the councilors of the Federal Judiciary and the electoral judges, may not be reduced during their term.
+
+Justices of the Supreme Court shall be appointed for a 15 years term, they may be removed only in the cases provided in the Title Four of this Constitution. Justices shall be entitled to a retirement payment at the end of their term.
+
+Supreme Court Justices cannot serve a second term, unless they have held the office as provisional or interim ministers.
+
+### Article 95
+
+To be appointed as Justice of the Supreme Court of Justice of the Nation, it is required:
+
+1. To be a Mexican citizen by birth, with legal capacity to exercise his political and civil rights.
+2. To be at least 35 years old to the date of the appointment.
+3. To hold, at the date of the appointment, a law degree for at least the past 10 years, issued by an institution legally empowered for that purpose.
+4. To have a good reputation and not have been convicted for a crime punishable by imprisonment for more than one year. However, should the crime have been robbery, fraud, forgery, breach of confidence or any other which would seriously damage good reputation, he shall be disqualified for office, whatever penalty may have been.
+5. To have lived in the country the last two years before appointment.
+6. To not have been Secretary of State, Attorney General, Senator, Federal Representative, Governor or Head of the Federal District Government for a whole year previous to the appointment date.
+
+Preferably, Justices shall be persons who have served with efficiency, ability and integrity in the dispensation of justice, or who have distinguished themselves by their honor, ability and career in the legal field.
+
+### Article 96
+
+For appointment of a Justice of the Supreme Court, the President of the Republic shall submit a list of three candidates to the Senate, who should present before the Senate. Within a 30-day period, the Senate shall choose one of the candidates by the vote of two thirds of the present members of the Senate. This period may not be extended. Should the Senate not decide within such term, then the President of the Republic shall appoint one person from the list he has proposed.
+
+If the Senate rejects all the three candidates in the list, the President of the Republic shall submit a new list of three candidates, considering the provisions established in the previous paragraph. If the Senate rejects this second list completely, the President of the Republic shall appoint one person from such list.
+
+### Article 97
+
+The Federal Judicial Council, based on objective criteria and observing the requirements and procedures established by law, shall appoint district and circuit judges. District and circuit judges shall be appointed for a six years term. At the end of such term, they may be ratified or promoted, in such case, they may be dismissed only in the cases described by the law and following the established procedure.
+
+The Supreme Court of Justice can request the Federal Judicial Council to investigate the behavior of a federal judge or magistrate.
+
+The Supreme Court of Justice shall have the power to appoint and remove its secretary, officials and employees. Magistrates and judges shall have the power to appoint and remove the officials and employees for the circuit courts and district courts, observing the regulation about the judicial career.
+
+Every four years, the Supreme Court of Justice, in plenary meeting, shall appoint a president for the Supreme Court from among its members. The President of the Supreme Court cannot be reelected for the next immediate term.
+
+Each minister of the Supreme Court of Justice, upon taking office, takes the following oath before the Senate:
+
+Speaker of the Senate: “Do you swear to loyally and patriotically perform the position of Justice of the Supreme Court of Justice of the Nation, which has been conferred upon you, and to observe and uphold the Political Constitution of the United Mexican States and the laws that emanate from it, pursuing the welfare and prosperity of the country?”
+
+Justice: “Yes, I do.”
+
+Speaker of the Senate: “If you do not fulfill these obligations, may the Nation demand it of you.”
+
+Circuit magistrates and district judges shall take the oath before the Supreme Court of Justice and the Federal Judicial Council.
+
+### Article 98
+
+Whenever the absence of a Justice exceeds one month, the President of the Republic shall submit a list of three candidates to the Senate in order to elect one interim Justice according to that established in the Article 96 of this Constitution.
+
+Should a Justice be absent by cause of death or any other definitive cause, the President of the Republic shall submit a list of three candidates to the Senate in order to elect one according to that established in the Article 96 of this Constitution.
+
+Resignation of a Justice shall be accepted only due to serious offence. Resignation shall be submitted to the President of the Republic, who, if accepts it, shall in turn submit resignation to the Senate.
+
+The Supreme Court of Justice can grant leave permits to the Justices if the leave do not exceed one month. Those leaves exceeding such term shall be granted by the President of the Republic with the Senate’s approval. No leave may exceed a term of two years.
+
+### Article 99
+
+The Electoral Court shall be the highest authority in this area and the specialized body of the Federal Judicial Branch, with exception of what is established in the Article 105, paragraph II, of this Constitution.
+
+The Electoral Court shall work on a permanent basis; it shall have a Superior Electoral Court and regional electoral courts. Resolving sessions of the Electoral Court shall be public in accordance with the law. The Electoral Court shall have enough legal and administrative personnel for an appropriate performance.
+
+The Superior Electoral Court shall be integrated by seven electoral magistrates, who shall appoint a president of the Electoral Court among them to hold the office for a period of four years.
+
+The Electoral Court shall resolve the issues listed below, in a definitive an irrefutable manner, observing the provisions established by this Constitution and the applicable law:
+
+1. Appeals of elections regarding federal representatives and senators.
+2. Contestation of election of the President of the Republic. Only the Superior Electoral Court can resolve such kind of contestations.
+	The Superior electoral Court and the regional electoral courts can annul an election only due to the causes expressly indicated in the law.
+	The Superior Electoral Court shall carry out the final count of votes in the election of the President of the Republic, provided that contestations thereof have been resolved. Then, the Electoral Court shall declare the validity of the election and shall name the elected President, i.e., the candidate who has obtained the highest number of votes.
+3. Contestations of acts and resolutions issued by the federal electoral authority, different to those mentioned in the two previous paragraphs.
+4. Contestations of final acts and resolutions issued by the state electoral authorities related to organization and assessment of elections; as well as controversies arisen during the election process that could affect such election process or the results thereof. This procedure shall be admissible only when the remedy requested is physically and legally possible within the electoral terms, and provided that it is feasible to be implemented before the date legally established for set up of the electoral bodies or for inauguration of elected officials.
+5. Contestations regarding acts and resolutions that infringe political-electoral rights of citizens: right to vote, right to be elected, right to freely join a party, right to peaceful assembly, according to this Constitution and laws. Contestations, filed by citizens against the political party they are affiliated, will be valid only if the plaintiff has exhausted all the instances provided by the party for solution of internal conflicts. The law shall establish regulations and terms for this kind of contestations.
+6. Labor conflicts between the Electoral Court and its employees.
+7. Labor conflicts or differences between the National Electoral Institute and its employees.
+8. Definition and imposition of sanctions by the National Electoral Institute on political parties, political associations, private or legal entities, either national or foreign, who have infringed the provisions provided by this Constitution and the laws.
+9. The matters that the National Electoral Institute submits to its consideration for the violations stated in the item III of the Article 41 and the 8th paragraph of the article 134 of this Constitution; to the regulation about the political and electoral propaganda and for performing anticipated pre-campaign and campaign acts.
+10. Others that the law establishes
+
+The courtrooms of the Electoral Court shall make use of the necessary coercive means in order to enforce their sentences and resolutions, in accordance with the terms established by law.
+
+Without prejudice to the Article 105 of this Constitution, the courtrooms of the Electoral Court can determine not to apply electoral laws that are contrary to this Constitution. Such kind of resolutions shall be limited to the concrete case in question. In such event, the Superior Electoral Court shall notify the Supreme Court of Justice of the Nation.
+
+When a courtroom of the Electoral Court defends an argument on the unconstitutionality of an act or resolution, or on the interpretation of a constitutional provision, and such argument may be contradictory to the one sustained by the Supreme Court of Justice or its courtrooms, then any of the Justices, courtrooms or parties can denounce the contradiction, according to the terms established by the law. The Supreme Court of Justice of the Nation, in plenary meeting, shall decide definitely which argument shall prevail. Such kind of resolutions shall not affect the cases already decided.
+
+This Constitution and the laws shall regulate the organization of the Electoral Court, the jurisdiction of the courtrooms, the procedures to decide the affairs, as well as the mechanisms to set mandatory legal precedents in this matter.
+
+The Superior Electoral Court can bring cases from regional electoral courts at their request. Likewise, the Superior Electoral Court can submit cases to the regional electoral courts for resolution. The law shall establish regulations and procedures to exercise such kind of power.
+
+In accordance with the terms provided by the law, the administration, supervision and discipline of the Electoral Court shall pertain to a committee of the Federal Judicial Council, which shall be composed of: a) the president of the Electoral Court, who shall chair; b) a magistrate from the Superior Electoral Court, elected by secret vote; and c) three members of the Federal Judicial Council. The Electoral Court shall submit its proposal about its own budget to the president of the Supreme Court of Justice in order to be included in the budget of the federal judicial branch. The Electoral Court shall issue its own internal regulations and decrees it should require to operate adequately.
+
+Magistrates composing the superior and the regional courts of the Electoral Court shall be proposed by the Supreme Court of Justice and elected by the vote of the two-thirds of the senators present. Election of the magistrates shall be staggered, observing the rules and procedures established by law.
+
+Magistrates composing the Superior Electoral Court shall meet the requirements stated by the law, which may not be less than those required to be a minister of the Supreme Court of Justice of the Nation. Magistrates shall hold the office for a term of nine years. This term cannot be extended. The magistrates of the Superior Electoral Court shall submit their resignations, leaves and permits to the Superior Court of the Electoral Court, which shall process and grant them, as applicable according to the Article 98 of this Constitution.
+
+Magistrates composing the regional courts of the Electoral Court shall meet the requirements stated by the law, which may not be less than those required to be a circuit magistrate. Regional magistrates shall hold the office for a term of nine years. This term cannot be extended, unless they get a promotion.
+
+In case of a definitive vacancy, a new magistrate shall be appointed, who shall finish the term.
+
+Labor relations between the Electoral Court and its employees shall be regulated by the rules applicable to the federal judicial branch and by the special laws and exceptions applicable to them.
+
+### Article 100
+
+The Federal Judicial Council shall be a body belonging to the federal judicial branch and shall have technical and operational independence and shall also be independent to issue its resolutions.
+
+The Federal Judicial Council shall be composed of seven members: the president of the Supreme Court of Justice, who shall also be the chairman of the Council; three councilors appointed by the Supreme Court in plenary meeting, by at least eight votes; the candidates proposed by the Supreme Court shall be circuit magistrates or district judges; two councilors appointed by the Senate and one councilor appointed by the President of the Republic.
+
+All councilor shall meet the requirements established in the Article 95 of this Constitution and shall be individuals who have distinguished themselves through professional and administrative capacity, honesty and honor in the conduct of their activities. In the case of the councilor appointed by the Supreme Court, they must also have a good professional reputation within the field of the judiciary.
+
+The Federal Judicial Council shall work at plenary meeting or at committees. The plenary meeting of the Council shall decide on appointment, assignment, ratification and dismissal of magistrates and judges, as well as on other affairs defined by the law.
+
+Except by the chairman of the Council, the councilors shall hold the office for a period of five years, they shall be replaced in a staggered manner. Councilors cannot be appointed for a second period.
+
+The councilors do not represent the institutions appointing them; therefore, they shall perform their duties in an independent and impartial manner. They may be dismissed only in accordance with the provisions established in the Title Four of this Constitution.
+
+The law shall create the basis to provide training and updating to the public officials, as well as to the development of the judicial career, which shall be governed by the principles of excellence, objectivity, impartiality, professionalism and independence.
+
+The Federal Judicial Council shall have the power to make and execute general covenants in order to achieve an adequate performance of its duties. The Supreme Court of Justice can request the Council to make and execute those general covenants that are necessary to achieve an adequate performance of the federal duties. The Supreme Court of justice can also review such covenants and, if necessary, revoke them by a majority of at least eight votes. The law shall regulate the exercise of these powers.
+
+Federal Judicial Council’s decisions are final and irrefutable, therefore, no trial or legal instrument is accepted against such decisions, except by decisions related to appointment, assignment, ratification and dismissal of magistrates and judges. Such kind of decisions can be reviewed by the Supreme Court of Justice only with the purpose to verify they have been taken according to the rules established in the applicable organic law.
+
+The Supreme Court of Justice shall propose its own budget, and the Federal Judicial Council shall propose the budget for the rest of the federal judicial branch, but complying with the provisions established in the Article 99, paragraph seventh, of this Constitution. These budgets shall be submitted by the President of the Supreme Court of Justice in order to include them into the Nation’s federal budget. The President of the Supreme Court of Justice shall manage the Supreme Court’s internal affairs.
+
+### Article 101
+
+Justices of the Supreme Court of Justice, circuit magistrates, district judges, their respective clerks, councilors of the Federal Judicial Council and the magistrates of the Superior Electoral Court cannot accept or perform any other job or assignment, either in a private company or in the federal or state government, or in the Federal District Government, except for those performed for free in scientific, educational, literary or charitable associations.
+
+Justices of the Supreme Court of Justice, circuit magistrates, district judges, councilors of the Federal Judicial Council and magistrates of the Superior Electoral Court, within the two years after finishing their respective term, shall not be allowed to work as attorneys, lawyers or legal representatives in any case before the agencies belonging to the federal judicial power.
+
+During the same term, the former Justices cannot be appointed for such positions mentioned in the Article 95, paragraph VI of this Constitution, unless they have been appointed as provisional or interim.
+
+Impediments established in this article will apply also to the judicial officials who are granted a leave permit.
+
+In the event of infringement of the provisions stated in the previous paragraphs, the offenders shall be punished with dismissal and loss of benefits, even benefits that could correspond to such position in the future, in addition to the other penalties established by law.
+
+### Article 102
+
+1. The Public Prosecution Service shall be organized by an Office of the Attorney General as an autonomous public organ with legal personality and endowed with its own patrimony.
+	To be appointed as Attorney General it is required to be a Mexican citizen by birth; to be at least thirty five years old on the day of the appointment; to hold at least for ten years the professional degree of bachelor in law; to enjoy a good reputation; and not to have been convicted for a serious crime.
+	The Attorney General shall remain in office for nine years and shall be appointed and removed according to the following provisions:
+	1. Given a definitive absence of the Attorney General, the Senate will have twenty business days to draft a list of at least ten candidates to occupy the office, once the list is approved by two thirds of the present members of the Senate it will be sent to the Federal Executive.
+		If the Federal Executive does not receive the list within the time limit stated in the previous paragraph, he will freely send a list of three candidates to the Senate and shall provisionally appoint the Attorney General who will be in functions until a definitive appointment is made according to this article. In this case, the Attorney General provisionally appointed shall participate in the list of three.
+	2. Once the Federal Executive receives the list described in paragraph I, the Executive shall send, within the next ten days, a list of only three candidates to the Senate for their consideration.
+	3. Based on the list of three sent by the Executive and previous appearance of the nominated persons, the Senate will appoint the Attorney General with the vote of the two thirds of the senators present. The Senate will have ten days to make the appointment.
+		In case that the Federal Executive does not send a list of three described in the previous paragraph the Senate will have ten days to appoint the Attorney General from the list of candidates described in fraction I of this article.
+		If the Senate does not comply with the time limits for the appointment as is stated in the previous paragraphs, the Executive shall appoint the Attorney General from the candidates drafted in the list of ten or, if it is the case, from the list of three presented.
+	4. The Executive may remove the Attorney General due to serious causes established by the law. An objection to the removal may be made by the vote of the majority members of the Senate present within a time limit of ten business days. In this case the Attorney General shall be reinstated to its functions. If the Senate does not pronounce itself about the removal it will be understood that there is no objection to it.
+	5. During the Senate recess, the Permanent Committee shall call for an extraordinary session immediately in order to decide about the appointment or removal objection of the Attorney General.
+	6. The absences of the Attorney General shall be substituted in the terms described by law.
+		The Public Prosecution Service shall have the power to prosecute in court all the federal crimes and to request precautionary measures or arrest warrant against the accused. The Public Prosecution Service has the duty to procure and submit evidence to prove the defendant’s liability in the acts that the law specifies as crimes; it will procure that federal criminal trials are carried out with regularity so that justice may be provided in a prompt and expeditious manner, it will also request the imposition of penalties and will intervene in all matters determined by law.
+		The Office of the Attorney General shall be organized, at least, by the specialized agency for the prosecution of electoral crimes and the anti-corruption specialized prosecution agency. The Attorney General has the power to appoint or remove the head prosecutors of these specialized agencies. The Senate may object the appointment or removal of those prosecutors by the vote of two thirds of the present members of the Senate within the time limit specified by law. If the Senate does not pronounce itself about the appointment or removal it would be understood that there is no objection to the act.
+		The law shall establishes the basis for the training and updating of the public servants that work at the Office of the Attorney General, as well as the basis for the professional development of them. These bases shall follow the principles of legality, objectivity, efficiency, professionalism, honesty, and the respect for human rights.
+		The Attorney General shall present before the Legislative and Executive powers a report of the activities performed by the Office he/she leads. When any of the Chambers of the Congress summons the Attorney General he shall appear before them to account for his performance or inform about his administration.
+		The Attorney General and his agents will be responsible of any fault, omission or violation to the law occurred by reason of their functions.
+2. The Congress of the Union and the state legislatures, under their respective jurisdictions, shall establish agencies directed to protect the human rights which are recognized by the Mexican legal system. Such agencies shall receive all the complaints against administrative actions or omissions committed against human rights by any public office or employee, except for the officials working for the federal judicial branch.
+	These agencies shall issue public recommendations, which shall not be compulsory. They also shall file accusations and complaints with the appropriate authorities. All public servants are obliged to answer the recommendations issued by these agencies. When the authorities or public servants responsible do not accept or enforce these recommendations, they must substantiate such refusal and make their refusal public. In addition, the Senate, the Permanent Committee or the state legislatures, as appropriate, may call, at the request of these agencies, the authorities or public servants responsible to appear and explain the reasons of such refusal.
+	These agencies shall not have jurisdiction over electoral and jurisdictional matters.
+	Such kind of agency, created by the Congress of the Union, shall be called National Human Rights Commission. It shall have managerial autonomy, legal personality and endowed with its own patrimony.
+	The state constitutions and the Federal District Charter shall establish and guarantee the autonomy of the agencies that protect the human rights.
+	The National Human Rights Commission shall have a Board of Advisors, which will be composed of ten councilors, who shall be elected by two thirds of the members present at the Senate, or at the Permanent Committee during the congress recess. The law shall establish the procedure to be followed by the Senate to nominate the candidates. Every year, the most senior councilors shall be replaced, unless they are proposed and ratified for a second term.
+	The President of the National Human Rights Commission, who shall also be the President of the Board of Advisors, shall be elected following the procedure established in the previous paragraph. The President of the National Human Rights Commission shall hold office for a five years term and may be reelected once only. He/she may be dismissed only in the cases established in the Title Four of this Constitution.
+	The election of the President of the National Human Rights Commission, as well as the members of the Board of Advisors and the heads of the state human rights commissions, shall be subject to a public consultation procedure, which shall meet the requirements established by law.
+	The President of the National Human Rights Commission shall submit an annual report to the three branches of the Union. For this purpose, he/she shall appear before both Houses under the terms established by law.
+	The National Human Rights Commission shall hear complaints against the resolutions, covenants and omissions made by the state human rights commissions.
+	The National Human Rights Commission can investigate serious violations of human rights when it considers so or at the request of the President of the Republic, the Senate, the House of Representatives, a governor, the Head of the Federal District Government, or a state congress.
+
+### Article 103
+
+The federal courts shall resolve all disputes concerning:
+
+1. Laws or acts issued by the authority, or omissions committed by the authority, which infringe the fundamental rights recognized and protected by this Constitution and the international treaties signed by Mexico.
+2. Laws or acts issued by the federal government and which break or restrict the sovereignty of the Mexican states or the Federal District.
+3. Laws and acts issued by the state authorities or the Federal District Government, which invade the federal authority’s jurisdiction.
+
+### Article 104
+
+The federal courts shall have jurisdiction over:
+
+1. Proceedings related to federal crimes.
+2. Any civil or mercantile controversy arisen about the observance and enforcement of federal laws or international treaties signed by Mexico. The plaintiff can filet such kind of controversy with an ordinary court when the controversy affects only private interests. Sentences pronounced by a trial court may be challenged with the appropriate appellate court.
+3. Review resources filed against final rulings pronounced by the contentious-administrative courts mentioned in the article 73, paragraph XXIX-H and in the Article 122, first basis, section V, subdivision (n), of this Constitution, but only in the cases indicated by the law. Review resources that are to be heard by the specialized circuit courts shall be subject to the formalities established by the statutory law of the articles 103 and 107 of this Constitution. No trial or legal instrument shall be admissible against the rulings pronounced by the specialized circuit courts on such review resources.
+4. Any controversy relating to maritime law.
+5. Any controversy where the Federal Government is an interested party.
+6. Any controversy or action mentioned in the Article 105, which can be resolved exclusively by the Supreme Court of Justice.
+7. All disputes between a Mexican state and one or more neighbor states.
+8. Al controversies regarding diplomats and consuls.
+
+### Article 105
+
+The Supreme Court of Justice of the Nation shall resolve the cases related to the following topics, in accordance with the provisions established by the applicable statutory law:
+
+1. About constitutional disputes, except for those referring to electoral matters, between:
+	1. The Federal Government and one state or the Federal District.
+		2. The Federal Government and one municipal authority.
+		3. The Executive Power and the Congress of the Union; the President of the Republic and any of the Houses; or the President of the Republic and the Permanent Committee, acting as federal bodies or as Federal District’s bodies.
+		4. Two states.
+		5. A state and the Federal District.
+		6. The Federal District and a municipal council.
+		7. Two municipal councils belonging to different states.
+		8. Two powers belonging to the same state about the constitutionality of their acts or regulations.
+		9. A state and one of its municipal councils, about the constitutionality of their acts or regulations.
+		10. A State and a municipal government belonging to another State, about the constitutionality of their acts or general norms.
+		11. Two governmental bodies belonging to the Federal District Government, about the constitutionality of their acts or general norms.
+		12. Two autonomous constitutional entities or between one autonomous constitutional entity and the Federal Executive or the Mexican Congress when the issue is related to the constitutionality of their acts or general norms. This article is also applicable to the National Transparency Agency \[organo garante\] established in the 6th Article of this Constitution.
+	The rulings taken by the Supreme Court of Justice, by a majority of eight vote, invalidating general provisions, shall have general compulsory effect; provided that the respective controversy is generated by the general provisions issued by a state or a municipal council, and which are challenged by the Federal Government; or by the general provisions issued by a municipal council and which has been challenged by the state; or in the cases indicated in paragraphs “c”, “h” and “k”.
+	In all other cases, the rulings pronounced by the Supreme Court of Justice shall have effect only on the particular case in question.
+2. Unconstitutionality lawsuits directed to raise a contradiction between a general regulation and this constitution.
+	Unconstitutionality lawsuits shall be initiated within the 30 days after publication of the regulation, they shall be initiated by:
+	1. Thirty-three percent of the members of the House of Representatives against federal laws or laws enacted by the Congress and applicable to Federal District.
+	2. Thirty-three percent of the members of the Senate against federal laws or laws enacted by the Congress and applicable to Federal District, or against international treaties signed by the Mexican State.
+	3. The Executive Federal, through its Legal Government Counselor, against general norms of the federation or the federal entities.
+	4. Thirty-three percent of the members of a state legislature, against laws enacted by such state legislature.
+	5. Thirty-three percent of the members of the Federal District’s Assembly of Representatives, against laws enacted by the Assembly.
+	6. The political parties registered before the National Electoral Institute, through their national leaders and against federal or local electoral laws; also, the state parties with local registration, through their leaders, only against laws enacted by the state legislature that granted them registration.
+	7. The National Human Rights Commission, against federal or state laws or laws enacted by the Federal District Government; as well as law against international treaties signed by the President of the Republic and approved by the Senate, which hamper the human rights system established in this Constitution and in the international treaties that Mexico has ratified. Likewise, the human right protection organs, equivalent to the National Commission for Human Rights in the federal entities against local legislation issued by the Local Congress and the Federal District Commission for Human Rights against the laws issued by the Federal District Legislative Assembly.
+	8. The National Transparency Agency \[organo garante\] established in the 6th Article of this Constitution against federal, local laws and laws of the Federal District, as well as international treaties signed by the Federal Executive and approved by the Senate when these diminish the right of access to information and the protection of personal data. Likewise, the local transparency agencies \[organos garantes locales\] may present an unconstitutional inquiry against the local laws enacted by the State Legislatures or the Federal District Transparency Agency can do so against the laws enacted by the Federal District Assembly.
+	9. The General Attorney in regard to the federal and local criminal laws and criminal procedure laws, as well as other issues related to his functions.
+	The only mechanism to present a non-conformity against electoral laws to the Constitution is the one stated in this article.
+	The federal and local electoral laws shall be enacted and issued at least ninety days before the electoral process begins given that these laws will be applied. During the electoral process there shall not be any fundamental legal modifications.
+	The resolutions of the Supreme Court of Justice may only declare the invalidity to the challenged norms if the resolution is approved by a majority of at least eight votes.
+3. By its own motion, or by motion justified and submitted of the corresponding unitary circuit court or of the Federal Executive through its Legal Government Counselor, as well as of the Attorney General in the matters that concern to the Public Prosecution Service. The Supreme Court of Justice can hear appeals against rulings pronounced by district judges, provided that the Federal Government is an interested party in the case and such case is transcendental.
+
+Invalidations mentioned in the sections I and II of this article may not have retroactive effects, except by criminal matter, where criminal general principles and legal provisions shall govern.
+
+In case of failure to comply with the rulings mentioned in the sections I and II of this article, the procedures established in the Article 107 section XVI of this Constitution shall be applied.
+
+### Article 106
+
+The Judicial Branch shall resolve the controversies that could arise between two federal courts related to their jurisdictions, or between a federal court and a state court, or between a federal court and a Federal District’s court, or between two courts belonging to different states, or between a state court and a Federal District’s Court.
+
+### Article 107
+
+All controversies mentioned in the article 103 of this Constitution, except for electoral controversies, shall follow the legal procedures and formalities established by the statutory law, according to the following principles:
+
+1. The constitutional adjudication (appeal on the grounds of unconstitutionality) shall be carried out at the request of the offended party. The offended party is the holder of an individual or collective right, which has been violated by the challenged act, affecting his/her legal framework, either directly or by the means of his/her special situation before the legal system.
+	Regarding acts or rulings pronounced by administrative or labor courts, the plaintiff must argue that he/she holds a subjective right that has been directly and personally affected.
+2. The sentence pronounced in a constitutional adjudication shall cover only to the plaintiffs, protecting them only in the specific case concerned in the complaint.
+	If a court rules unconstitutionality of a general provision for a second consecutive time in constitutional adjudications, the Supreme Court of Justice of the Nation must notify the authority that enacted such provision.
+	When the bodies belonging to the Federal Judicial Branch establish legal precedents by repetition, ordering unconstitutionality of a general provision, the Supreme Court of Justice of the Nation shall notify the authority that enacted such provision. If after 90 days the unconstitutionality is not overcome, the Supreme Court of Justice of the Nation shall issue a general declaration of unconstitutionality, indicating its scope and conditions, according to the statutory law. Such declaration must be approved by a majority of 8 votes.
+	The previous two paragraphs do not apply to general provisions for taxation.
+	In a constitutional adjudication, any deficiency regarding the terms “violation” and “grievances” should be corrected by the court, according to that established in the statutory law.
+	Whenever the acts claimed in the constitutional adjudication deprive or may deprive the farming cooperatives or communities or their members of their lands, waters, pasture and mountains, all evidence that could benefit any of the aforesaid entities or individuals must be obtained at the court’s own motion, and any proceedings that could be necessary to prove their rights must be ordered to establish their agrarian rights. Also, the nature and consequences of the claimed acts shall be defined.
+	In the constitutional adjudication mentioned in the preceding paragraph, dismissal of the suit because of procedural inactivity or by discontinuance shall not be admissible to the detriment of farming cooperatives or indigenous communities, or to the detriment of a native or joint-title farmer. However, this kind of proceedings shall be admissible to their benefit. Waiving or express consent shall not be accepted when the claimed acts affect the community’s rights, unless waiving or express consent are agreed by the General Assembly of the farming cooperative.
+3. The constitutional adjudication against rulings pronounced by judicial, administrative or labor courts shall be admissible only in the following cases:
+	1. Against final rulings, binding judgments or resolutions that end the trial, no matter if infringement is committed by such rulings, binding judgments or resolutions, or during the proceeding affecting the plaintiff’s defense and the verdict. Regarding the constitutional adjudication mentioned in this subdivision and in the section V of this article, the specialized circuit court shall decide on all infringements to the proceedings and the corrections to the brief, establishing the terms for the new ruling. If such violations were not reported in the first constitutional adjudication, and the specialized court did not decided on the subject, then they cannot be invoked in a second constitutional adjudication.
+		The party who has obtained a favorable ruling, as well the party who has legal interest that the act in question persists, can file a constitutional adjudication in addition to the one filed by any of the parties involved in the trial that generated the challenged act. The law shall determine the procedure and requirements to file such trial.
+		For the constitutional adjudication admissibility, first the plaintiff must exhaust the ordinary instruments provided by the applicable law, which may be suitable to modify or revoke the final sentence, binding judgment or ruling, except for the cases when the law allows plaintiff to waive such resources.
+		Violations to the procedural law should be invoked when challenging the final rulings, binding judgments or resolutions that end the trial, provided that the plaintiff has challenged them through the ordinary instruments. However, this requirement does not apply to the constitutional adjudication filed against acts which affect the rights of minors or disabled persons, or affect the marital status or the family’s order and stability, or the criminal acts filed by the defendant.
+		2. Against acts in trial which enforcement would render them impossible to restitute, provided that all applicable appeals have been exhausted.
+		3. Against acts affecting persons who are not involved in the trial.
+4. Regarding the administrative matter, the constitutional adjudication is accepted also against rulings pronounced by other authorities, different to the judicial, administrative and labor courts, which caused irreparable offence. It is necessary to exhaust these means of defense, provided that the effects of such acts have been suspended by the court or by the plaintiff through the appropriate legal instrument. In this case, the constitutional adjudication shall have the same scope than the one indicated by the statutory law, and the requirements will be the same as required to grant the final suspension. Also, the term shall not be greater than the one established for provisional suspension, regardless of whether the act may be suspended or not, according to the law.
+	It is not necessary to exhaust such means of defense when the challenged act has no grounds, or when only direct violations to this Constitution are argued.
+5. The constitutional adjudication against final sentences, binding judgments or rulings that end the trial, shall be filed with the competent specialized circuit court, according to the law, in the following cases:
+	1. Relating to criminal matter, against final rulings pronounced by federal, ordinary or military courts.
+		2. Relating to administrative matter, when private persons challenge final sentences or rulings pronounced by administrative or judicial courts, provided that such sentences or rulings are not repairable through a legal instrument, trial or any other ordinary means.
+		3. Relating to civil matter, against final sentences pronounced in federal trials, or in federal or local mercantile trials, or in trials for common crimes.
+		In federal civil cases, sentences may be challenged through the constitutional adjudication by any of the interested parties, even the Federal Government, in defense of its pecuniary interests.
+		4. Relating to labor issues, when adjudication pronounced by a federal or local Commission for Conciliation and Arbitration or by the Federal Court of Conciliation and Arbitration for public employees were challenged.
+	The Supreme Court of Justice may, by its own motion or by motion of the collegiate circuit court, the Attorney General in the issues that concern to the Public Prosecution Service, or by the Federal Executive through its Legal Government Counselor, hear direct constitutional adjudications given that are considered important or transcendental.
+6. The Statutory Law shall indicate the procedure and conditions to be met by the collegiate circuit courts and the Supreme Court in order to pronounce a ruling relating to section V of this Article.
+7. The constitutional adjudication against acts or omissions committed during a trial, in the trial context or after that the trial, or against acts that affect persons who are not involved in the trial, or against general laws or administrative authority’s acts or omissions, shall be lodged before the district judge having jurisdiction over the place where the harmful actions have been committed or have been tried to be committed. The procedure for such constitutional adjudication is as follows: 1) authority’s report, 2) a hearing, 3) receipt of evidence provided by the interested parties, and 4) argument hearing. The sentence shall be pronounced in the hearing.
+8. The sentences pronounced as a result of a constitutional adjudication by a district judge or a unitary circuit court may be reviewed. Such review shall be lodged before the Supreme Court of Justice:
+	1. In the event that the unconstitutionality still remains after the constitutional adjudication filed against general provisions that directly violates the Constitution.
+		2. In the cases mentioned in the Article 103, sections II and III, of this Constitution.
+	The Supreme Court of Justice may, by its own motion or by motion of the collegiate circuit court or the Attorney General in the issues that concern to the Public Prosecution Service, or by the Federal Executive through its Legal Government Counselor, hear constitutional adjudications in review process that are considered important or transcendental.
+	In all other cases, reviews shall be lodged before a collegiate circuit court, which sentence shall be final and shall not admit any further review.
+9. Regarding the direct constitutional adjudication, the review resource is appropriate to challenge the sentences concerning the unconstitutionality of general provisions, or make a direct interpretation of a constitutional provision, or failed to rule on these issues, provided that the Supreme Court of Justice considers that such rulings create an important and transcendent criterion. In the constitutional adjudication, only the constitutional issues shall be analyzed.
+10. Claimed acts may be suspended in the cases and under the terms established by statutory law. For this purpose, the adjudication judge shall make an analysis on the law and public interest.
+	Regarding criminal matter, such suspension shall be applied while notifying the constitutional adjudication lodged. Regarding civil, mercantile and administrative matters, such suspension shall be applied when the plaintiff pays a bail, which shall be used to pay for the damages caused by the suspension to a third party. Such suspension shall be void if the other party pays an indemnity bond in order to assure re-installment of the situation as if the constitutional adjudication has been granted.
+11. The direct constitutional adjudication shall be lodged before the authority responsible, which shall rule on the suspension. In other cases, suspension shall be filed with the district court or the unitary circuit court, which shall rule on suspension, or with the state courts where allowed by law.
+12. Appeals against violations to the constitutional rights provided under articles 16, related to criminal matter, 19 and 20, shall be filed with the superior court standing directly above the court that committed the infringement, or with the appropriate district judge or unitary circuit court. The rulings pronounced hereby may be reviewed according to the provisions established in the paragraph VIII of this article.
+	In the event that the district judge or unitary circuit court does not reside in the same place than the authority responsible, then the law shall define the appropriate judge or court to lodge the constitutional adjudication. Such judge or court can suspend temporarily the challenged act in accordance with the law.
+13. In the event that collegiate courts of the same circuit defend contradictory criteria regarding constitutional adjudications under their jurisdiction, then the Attorney General, in regard to criminal and criminal procedures issues, as well as in issues related to his function; the collegiate circuit courts and their members; the district judges; or the parties involved can report this contradiction to the appropriate circuit court, which shall decide which argument shall prevail as legal precedent.
+	In the event that circuit courts belonging to different circuits, or the specialized circuit courts belonging to the same circuit, or collegiate circuit courts of the same circuit with different specialization defend contradictory criteria in the matters of their jurisdiction, then the ministers of the Supreme Court of Justice of the Nation, the circuit courts or the bodies mentioned in the previous paragraph can report this contradiction to the Supreme Court of Justice, so that the Plenary Meeting or the respective courtroom decides which argument shall prevail.
+	In the event that the courtrooms belonging to the Supreme Court of the Nation defend contradictory criteria in the constitutional adjudications under their jurisdiction, then the ministers of the Supreme Court of Justice of the Nation; the collegiate circuit courts and their members; the district judges; the Attorney General in criminal or criminal procedures issues or in matters related to his functions; the Federal Executive through its Legal Government Counselor; or the parties involved can report this contradiction to the Supreme Court of Justice in their plenary meeting so that they can decide which argument shall prevail according to the laws and norms.
+	Rulings pronounced by the plenary meeting of the Supreme Court of Justice or by one of its courtrooms, or by the circuit courts according to the previous paragraphs, shall only establish jurisprudence. They shall not affect the specific legal situations derived from the sentences pronounced in the trials where contradictory legal precedents arose.
+14. (Repealed by the decree published on June 6, 2011)
+15. The Attorney General, or the federal public prosecutor appointed by for that effect, shall be an interested party in all constitutional adjudications in which the challenged act involves procedures in regard to criminal matters and those that the law establishes.
+16. If the authority responsible fails to enforce the sentence pronounced in the constitutional adjudication, but such failure is justified, then the Supreme Court of Justice of the Nation shall grant the authority responsible a reasonable term to enforce the sentence, according to the procedure provided by the statutory law. This term may be extended at the request of the authority responsible. If failure to observe the sentence is not justified, or the term has expired, then the Supreme Court of Justice shall dismiss the head of the authority responsible from office and bring him/her to trial before the appropriate district judge. This will apply also to the hierarchical superior of the authority responsible if he/she is liable, as well as to the previous heads of the authority responsible, if they failed to enforce the sentence.
+	If the act in question is repeated, given that the constitutional adjudication has been granted, the Supreme Court of Justice shall dismiss the head of the authority responsible from office, according to the procedure established by the law. The Supreme Court shall notify the Federal Public Prosecution Service, unless the authority responsible acted with no premeditation and cancels the act in question before the Supreme Court of Justice pronounces the respective ruling.
+	The Supreme Court of Justice can replace the sentence pronounced in a constitutional adjudication, by its own motion or at the request of plaintiff, when the execution of such sentence affects seriously the society or third parties, more than the benefits granted to the plaintiff, or when it is impossible or excessively onerous restore the previous situation. Then, the sentence should be exchanged by an economic compensation to the plaintiff. For this purpose, the parties shall sign a covenant before the Supreme Court of Justice.
+	The constitutional adjudication cannot be filed until the sentence is enforced.
+17. The responsible authority shall be prosecuted before the appropriate authority if it fails to suspend the challenged act having the duty to do so, as well as if it accepts a false or inadequate bail.
+18. (Repealed by the decree published on September 03, 1993)
+
+### TITLE FOUR. Public Servants’ Accountability, Individuals related to Administrative Liabilities or Corruption Acts
+
+### Article 108
+
+For the purposes of this Title, public servants or civil servants are the representatives elected by popular vote; the members of the Federal Judicial Branch; the members of the Judicial Branch of the Federal District; the officials, the public employees and, in general, any person who holds any position or assignment in the Congress of the Union, in the Federal District’s Assembly of Representatives, in the federal government or in the Federal District Government. Public servants are also the persons who work in the autonomous bodies created by this Constitution. Public servants are accountable for the acts or omissions they commit in the performance of their duties.
+
+The President of the Republic, during his term in office, may be impeached only for treason or serious common crimes.
+
+Governors, representatives of the State Houses, magistrates of the States Supreme Courts, members of the local Judicial Councils, members of the Municipal Councils and the members of the autonomous entities established in the local constitutions or the autonomous entities established by the Federal District Charter, shall be liable for infringements against this Constitution and federal laws, as well as for mishandling federal funds and resources.
+
+The constitutions of the States shall detail the public servants that perform any job, position or assignment in the state or municipal government according to the terms described in the first paragraph of this article in order to establish the effects of their performance. Those public servants shall be accountable for the mishandling of public resources or for public debt.
+
+The public servants described in this article shall submit, under oath, a declaration of assets and properties and a declaration of interests before the corresponding authorities and according to the terms defined by the law.
+
+### Article 109
+
+Public servants and individuals that infringe the law in regard to the responsibilities with the State shall be penalized according to the following:
+
+1. The public servants mentioned in the Article 110 can be impeached and punished when during their time in office they commit acts or omissions that affect fundamental public interests or they affect their proper exercise.
+	Impeachment due to expression of ideas is not accepted.
+2. Perpetration of crimes by any public servant or individuals that commit corruption acts shall be prosecuted according to the applicable criminal law.
+	The laws shall establish the cases and circumstances in which criminal sanction shall proceed due to illicit enrichment to the public servants that during their term in office or because of it increase their assets or estate and which legal origin can not be proved. The laws shall state that this type of offence shall require confiscation of the assets as penalty among others that may apply.
+3. Administrative penalties shall be imposed to the public servants who commit acts or omissions affecting their legality, honesty, loyalty, impartiality and efficiency while performing their duties or commissions. Reprimand, suspension, dismissal, and banning constitute administrative penalties. Economic penalties shall be established according to the economic benefits that the accused obtained by the misuse or abuse of public office. The law shall determine the procedures for the investigation and prosecution of these acts.
+	The Federal Auditing Office, the Comptroller Offices or their partners in the local governments will investigate the administrative offences accordingly and the resolution will be made by the Administrative Justice Court that correspond. Other offences and sanctions will be resolved by the internal comptroller offices.
+	For the investigation, prosecution and resolution of the administrative responsibilities of the member of the Federal Judicial Power the procedures will follow the Article 94 of this Constitution regardless the powers of the Federal Auditing Office in terms of the accountability on the management, use and safekeeping of public resources.
+	The law shall establish the cases and procedures to challenge the categories given by the internal comptroller offices about administrative offences as severe or not severe.
+	The federal agencies shall have a comptroller office with the powers stated by the law to prevent, correct and investigate those acts or omissions that may constitute administrative responsibilities. The comptroller offices may punish those administrative offences that are not in the jurisdiction of the Federal Administrative Court, it also may supervise the revenues, expenditures, management, safe-keeping and use of the federal public resources, as well as to present inquiries for acts and omissions that may constitute a criminal offence before the Specialized Anti-Corruption Prosecution Office.
+	The local and municipal public agencies, as well as the public agencies of the Federal District and its territorial divisions shall have internal comptroller offices that will be responsible for the local supervision and powers stated in the previous paragraph
+4. The Administrative Justice Courts shall impose economic sanctions, disqualifications to participate in public tenders, leasing other services; as well as to establish the restoration of the damages caused to the Treasury or the federal, local or municipal agencies to those individuals that participated in serious administrative offences regardless of other type of responsibilities that emerge from these actions. Companies shall be punished in terms of this provision when the acts related to serious administrative offences are performed by individuals that act in representation of the company or to its benefit. The Court may also order suspension of activities, dissolution or intervention to the respective company when the offences produce damages to the Treasury or federal, local or municipal agencies, given that this company has obtained a pecuniary benefit of these activities and that there is proof that its administrative, supervision organs or its partners have systematically used the company to participate in administrative offences. In this case, the punishment will be executed once the final resolution is issued. The laws shall establish the procedures to the investigation and punishment to those acts and omissions.
+	The procedures for the punishment application in the cases mentioned in the previous paragraph shall be independent. Never shall a punishment for one single action be applied more than once.
+
+Any citizen, by its own responsibility and presenting the corresponding evidence, may present before the House of Representatives an inquiry about the acts and omissions mentioned in this article.
+
+Provisions in regard to fiscal and financial secrecy or protection of data in deposit, management, savings or investment operations shall not proceed when the agencies responsible of investigation and sanction of administrative responsibilities or corruption acts are performing its duties. The law shall establish the procedures in which this information will be delivered.
+
+The Federal Auditing Office and the Ministry responsible for the internal control of the Federal Executive, may use the resolutions of the Specialized Anti-Corruption Prosecution Office and the Federal Administrative Justice Court, as stated in article 20 part C item VII and article 104 of this Constitution.
+
+The State’s responsibility for the damages caused to the rights and property of the individuals due to its irregular administration shall be objective and direct. The individuals will have the right to compensation according to the basis, limits and procedures established by law.
+
+### Article 110
+
+The following civil servants may be impeached: members of the Senate, members of the House of Representatives, Justices of the Supreme Court of Justice, Councilors of the Federal Judicial Council, Secretaries of State, members of the Federal District’s Assembly of Representatives, the Head of the Federal District Government, the Attorney General of the Nation, the Attorney General of the Federal District, the circuit magistrates, district judges, magistrates and judges of ordinary courts in the Federal District, Councilors of the Federal District’s Judicial Council, the President of the Electoral Council, Electoral Councilors and the Executive Secretary of the National Electoral Institute, magistrates of the Electoral Court, the members of the constitutional autonomous organs, and the general managers of the decentralized agencies, semipublic companies, associations assimilated by semipublic companies and public trusts.
+
+Governors, local representatives, magistrates of the local superior courts and the members of the local judicial councils, as well as the members of the local agencies that the local constitutions and the Federal District Charter grants autonomy; they may only be impeached in reason of: a) serious infringement of this Constitution and the federal laws derived from it, b) mishandling federal funds and resources. However, the ruling shall be only declarative and shall be notified to the state legislature in order to implement the pertinent proceeding.
+
+Penalties for public servants shall be: dismissal from office and disqualification to perform any public function, job, position or assignment in the public service.
+
+The procedure shall be as follows: the House of Representatives shall substantiate the case, shall hear the accused and the absolute majority of the members of the House shall declare the impeachment. Then the House of Representatives shall submit the impeachment to the Senate.
+
+The Senate shall carry out the necessary proceedings and shall hear the accused. The Senate then shall become jury and shall impose the appropriate penalty by the vote of the two-thirds of the members present.
+
+Rulings pronounced by the House of Representatives and the Senate are irrefutable.
+
+### Article 111
+
+Members of the Senate, members of the Chamber of Deputies, Justices of the Supreme Court of Justice, magistrates of the Supreme Electoral Court, Councilors of the Federal Judicial Council, Secretaries of State, members of the Federal District’s Assembly of Representatives, the Head of the Federal District Government, the Attorney General of the Nation, the Attorney General of the Federal District, as well as the President of the Electoral Council and Electoral Councilors of the General Council of the National Electoral Institute may be indicted for perpetration of crimes during their terms. The House of Representatives shall declare, by absolute majority of the present deputies, whether there are grounds to proceed against the accused.
+
+A negative declaration by the House of Representatives shall suspend any further procedure. However, such a suspension shall not resolve the indictment in a definitive way. Once the accused finish his term in office, a criminal trial shall begin if the charges remain.
+
+If the House of Representatives declare the indictment, the individual shall be turned over the respective authorities, which shall proceed according to the law.
+
+The President of the Republic may be charged only before the Senate and according to the provisions established by the Article 110. The senate shall resolve the case observing the applicable criminal law.
+
+Governors, local representatives, magistrates of the local superior courts and the members of the local judicial council, and members of the local entities that are granted autonomy by the local constitution or the Federal District Charter may be indicted for federal crimes and shall follow the procedures established in this article. However, the indictment ruling shall be only declarative and shall be notified to the state legislature in order to implement the pertinent proceedings.
+
+Rulings pronounced by the House of Representatives and the Senate are irrefutable.
+
+If the resolution declares the indictment, the public servant shall be removed from office while is on trial. In the event of acquittal, the accused can resume duties. In the event of guilty verdict, pardon may not be granted to the accused, provided that the crime was perpetrated during his term.
+
+Related to lawsuits on civil matter against any public servant, it is not necessary that the Congress declare the indictment.
+
+Prison sentences shall be applied according to that established in the criminal law. In the case of crimes where the perpetrator obtains economic benefit or cause damage or loss to property, prison sentence shall be proportional to the profit obtained by the accused and to the damages and losses caused by his unlawful conduct.
+
+Economic penalties cannot exceed three times the amount of gains obtained or the damages or losses caused.
+
+### Article 112
+
+It is not necessary that the House of Representatives declare the indictment when any public servant, mentioned in the first paragraph of the Article 111, perpetrates a crime when he is not holding office.
+
+However, if the public servant resumes duties or has been appointed or elected for a new position, which is mentioned in the Article 111, he shall be indicted according to such article.
+
+### Article 113
+
+The National Anticorruption System will be the coordinating entity between the authorities of every government level responsible for prevention, detection and punishment of administrative responsibilities in corruption acts, as well as the surveillance and control of public resources. For the fulfillment of its objectives it will adhere to the following provisions:
+
+1. The National Anticorruption System shall have a Coordinating Committee that will be formed with the directors of: the Federal Auditing Office, the Specialized Anticorruption Prosecution Office, the Federal Ministry responsible for internal control, the president of the Administrative Justice Court, the president of the National Transparency Agency, one representative of the Federal Judicial Council and one representative of the Citizen Participation Committee.
+2. The Citizen Participation Committee of the National Anticorruption System shall be formed by five citizens that have distinguished themselves for their contributions to transparency, accountability and the anticorruption movement. They will be nominated according to the law.
+3. The Coordination Committee of the National Anticorruption System will be responsible for:
+	1. The establishment of a mechanism of coordination with the local systems
+		2. The design and advancement of comprehensive policies in regard to accountability and control of public resources, policies about prevention, control and deterrence of administrative offences and acts of corruption with special focus on the causes of these acts.
+		3. The establishments of mechanisms for the generation, systematization, sharing and update of the information in regard to these topics that the institutions generate.
+		4. The establishment of basis and principles for the effective coordination between authorities of different government levels in regard to accountability policies and control of public resources.
+		5. The creation of an annual report that details the results and progress in the exercise of their functions and the implementation of anticorruption of policies and programs.
+		As a result of this report, the System may issue nonbinding recommendations to the corresponding authority in order for them to implement the measures and procedures to strengthen the institution and prevent administrative offences and corruption acts. The authorities that receive these recommendations shall inform the Committee about the implementation of those recommendations.
+
+The States and the Federal District shall establish local anticorruption systems to coordinate the corresponding local authorities about the prevention, detection and punishment of administrative responsibilities and corruption acts.
+
+### Article 114
+
+Impeachment against a public servant can be initiated only during the period of time he is holding office and within the first year after such term. Punishments shall be applied within the first year after that proceedings have initiated.
+
+Crimes perpetrated by a public servant during the period of time he is holding the office shall be punished according to the statutes of limitations provided by the criminal law. Such terms shall never be shorter than three years. Statute of limitations shall be interrupted while the public servant holds any of the offices listed in the Article 111.
+
+The law shall establish the cases where the statute of limitations shall be applied to administrative liability, taking into account the nature and consequences of the acts or omissions mentioned in the Article 109, paragraph III. Statute of limitations shall never be shorter than seven years for serious acts or omissions.
+
+### TITLE FIVE. Mexican States and the Federal District
+
+### Article 115
+
+The states comprising the United Mexican States shall adopt a republican, representative, democratic, secular and popular form of government for their own organization. The states shall be divided into municipalities, which shall be the basis of the political and administrative organization according to the following criteria:
+
+1. Each municipality shall be governed by Municipal Council, which shall be composed of one Mayor and the number of councilors and community representatives established by law. This Constitution grants the governing powers to the Municipal Council exclusively and there shall not be an intermediate authority between the Municipal Council and the local governments.
+	The local constitutions shall establish the consecutive election for the same office to the Presidents of the Municipal Councils, councilors and community representatives for an additional term in office whenever the term in office does not exceeds three years. These candidates shall only be nominated by the same party or coalition party that nominated them to their first term in office, unless they had resigned or lost their membership before the first half of their term in office.
+	State legislatures, by resolution of the two-thirds of their members, can suspend a Municipal Council, eliminate it or suspend or revoke the powers of any of its members due to a serious cause mentioned by law, provided that the members of the Municipal Council have had sufficient opportunity to submit evidence and provide arguments that to their consideration may be useful.
+	Substitutes shall be appointed to the vacant positions, according to the procedures described by the law.
+	In the event that the state legislature eliminates a Municipal Council, or in the event of resignation or absolute absence of the majority of its members, when the law does not allow the substitutes to finish the term nor to call elections, the state legislature shall appoint some inhabitants to make up a city board, which shall finish the term. The law shall establish the number of members for such city board. The members of the city board shall meet the same requirements than the councilors.
+2. Municipalities shall be vested with legal status and shall manage their own assets in accordance with the law.
+	The State legislatures shall enact laws to empower Municipal Councils so they can approve and issue statutory laws, regulations and administrative rulings within their respective jurisdictions. The Municipal Councils shall have the powers to organize the municipal public administration and to regulate public procedures, functions, affairs and services and to encourage citizen participation.
+	The purpose of such laws shall be to define:
+	1. The general basis of the municipal public administration and the administrative procedures, including legal challenges and the bodies that shall resolve the controversies that could arise between the municipal government and private individuals, observing the principles of equality, open trial, hearing and legality.
+	2. The cases where the consent of the two-thirds of the Municipal Council members is required to pronounce rulings affecting the Municipal Council’s assets, or to approve agreements or acts for a period longer than the term of the Municipal Council in question.
+	3. The norms to be applied to the agreements mentioned in the items III and IV of this article and in the second paragraph of the item VII of Article 116 of this Constitution.
+	4. The procedure to be followed by the state government in order to take charge of a local function or service due to the lack of a service provision agreement and by consideration of the legislature that the municipal government is not able to provide the service. In this case, it shall be necessary a previous request from the Municipal Council in question, approved by at least the two-thirds of its members.
+	5. The provisions to be applied in those municipalities where there are not ordinances or statutory laws.
+	State legislatures shall establish the procedures to be followed in order to resolve conflicts that may arise between the municipal councils and the state government, or between two or more municipal councils, caused by the acts mentioned in the previous paragraphs “c” and “d”.
+3. City Councils shall be in charge of the following functions and public services:
+	1. Drinking water, drainage, sewerage system, treatment and disposal of sewage.
+		2. Street lighting.
+		3. Garbage cleaning, collection, transport, treatment and final disposal.
+		4. Municipal markets and wholesale markets.
+		5. Cemeteries.
+		6. Slaughterhouse.
+		7. Streets, parks and gardens, as well as their equipment.
+		8. Public security, according to the provisions established by the Article 21 of this Constitution, as well as preventive and transit police.
+		9. Other affairs determined by the state legislature, depending on the territorial, social and economic conditions of the municipality and on the administrative and financial resources of the Municipal Council.
+	The Municipal Councils, prior agreement of their councils, can coordinate their activities and collaborate to improve public services and their functions. For this purpose, the approval of the state legislature is necessary. When two or more Municipal Councils belonging to different states want to collaborate, the approval of their respective state legislature is necessary. Likewise, a Municipal Council and the respective state can make and execute agreements to authorize the state to temporarily take charge of one or some public services, directly or through the appropriate body, or when the municipality and the state agree to provide public services in a coordinated manner.
+	Indigenous communities belonging to the same municipality can also coordinate their activities and collaborate according to the law and for the purposes indicated thereof.
+4. Municipal Councils shall freely manage their properties and assets, which shall be composed of the yields generated by their properties, as well as of the taxes and other revenues authorized by the state legislatures. Municipal Council’s assets shall include:
+	1. Property tax and taxes on breaking up, division, consolidation, improvement and transfer of property, as well as any others that result from a change in the value of real estate.
+		City Councils can make and execute agreements with the state to authorize the state government to take charge of some functions regarding to management of local taxes.
+		2. Federal contributions authorized annually by the state legislature, specifying conditions, amounts and terms.
+		3. Revenue generated by provision of public services.
+		Federal laws shall not restrict the power of the state legislatures to fix the taxes and prices of the public services mentioned in the previous paragraphs “a” and “c”. Federal laws shall not grant tax exemptions thereof. State laws shall not grant tax exemptions or allowances to the benefit of any person or institution. Only the properties belonging to the federal, state and municipal governments shall be exempt from taxes, provided that they are not used by semipublic or private entities for purposes different to those defined as public purpose.
+		Municipal Councils shall submit to the state legislature their proposal for tolls, charges, rates, taxes and the table of property value, which serve as basis to fix the property tax.
+		State legislatures shall approve the revenue law for the Municipal Councils, and shall review their public accounts. The Municipal Council, based on the available revenue, shall approve the expense budget and it shall include detail information about the salaries of the municipal public servants, according to that established in the Article 127 of this Constitution.
+		The resources constituting the municipal treasury shall be applied directly by the Municipal Council or by whomever it authorizes, according to the law.
+5. In accordance with the terms provided by the applicable federal and state laws, the Municipal Councils shall have power to:
+	1. Plan, approve and manage urbanization and urban development.
+		2. Participate in the creation and administration of its own territorial reserves.
+		3. Participate in regional development planning, according to the general plans. Federal and state governments shall invite Municipal Councils to participate in regional development planning.
+		4. Authorize, control and supervise land use within their territory and jurisdiction.
+		5. Intervene in regularization of urban land tenure.
+		6. Grant construction permits.
+		7. Participate in creation and administration of nature reserves and in development and application of rules on this topic.
+		8. Intervene in development and implementation of public transportation programs, provided that such programs affect the City Council’s territory.
+		9. Make and execute agreements to manage and protect federal zones.
+	The Municipal Councils shall have power to issue administrative regulations and provisions necessary for the performance of their duties, where applicable and according to the purposes established in the third paragraph of the Article 27 of this Constitution.
+6. When two or more urban settlements located in two or more different municipalities or states tend to form one single urban settlement, then the federal, state and municipal governments involved shall collaborate to plan and regulate the development of such urban settlement, observing the applicable federal law.
+7. Preventive police shall be under the Mayor’s command, according to the terms established by the State Public Security Act. Municipal police shall obey the orders given by the Governor in extreme cases or serious disturbances of public order.
+	The President of the Republic shall have command of public force in the place where he resides regularly or temporarily.
+8. State laws shall introduce the principle of proportional representation in the election of the Municipal Council members in all municipalities.
+	Labor relations between the Municipal Council and its employees shall be guided by the applicable state laws in accordance with the Article 123 of this Constitution and its statutory provisions.
+9. (Repealed by the decree published on March 17, 1987)
+10. (Repealed by the decree published on March 17, 1987)
+
+### Article 116
+
+Public power of a state shall be divided into three branches: executive, legislative and judicial. Two or more of these powers cannot be united in one single person or corporation, nor shall the legislative branch be vested in one single person.
+
+Public powers of a state shall be subjected to the state constitution, according to the following provisions:
+
+1. State Governors shall not hold the office for more than a six-year term.
+	Governors and state representatives for the Local Congress shall be elected by direct vote in accordance with the provisions established in the applicable electoral law.
+	State Governors elected by popular vote, in ordinary or extraordinary elections, cannot have another term in office by any motive, not even as interim, provisional or substitute.
+	The following public servants may never be elected for the immediate subsequent term:
+	1. The substitute of a governor or the person appointed to finish the term due to the absolute absence of the incumbent constitutional governor, even if the position has a different name.
+	2. The interim governor, the provisional governor or the person appointed to substitute the governor during temporary absences, whenever this takes place during the last two years of the governor’s term.
+	To become State Governor, a person shall: a) be a Mexican citizen by birth, b) be a native of the respective state or live in such state for no less than five years immediately before the day of the election, and c) be at least 30 years old the day of the election. The state constitution can establish a younger age for the governor.
+2. The quantity of representatives in the state congress shall be proportional to the number of inhabitants. The minimum quantity of representatives shall be seven, even if the state has a population of less than 400 000 inhabitants. The states with a population between 400,000 and 800,000 inhabitants shall have at least of nine representatives. The states having a population of more than 800,000 inhabitants shall have a minimum of 11 representatives.
+	The state constitutions shall establish the consecutive election for representatives of the Local Congress up to four consecutive periods. For this matter, the candidate shall only be nominated by the same party or any coalition party that nominated him/her for the first term in office; unless, he/she had resigned or lost its membership before the first half of their tenure.
+	The local Congress shall be formed with elected deputies according to the principles of relative majority and proportional representation in the terms established by law. In no case a political party may have a number of deputies, by both relative majority and proportional representation principles, that exceeds, in percentage of the total legislature, by eight points its percentage of votes obtained in the election. This principle shall not be applied to the political party that by its triumphs in uninominal districts gets a percentage of representatives from the total legislature larger than the addition of its percentage of votes obtained in the election plus eight percentage points. Likewise, the minimum percentage of representation of a political party shall not be less than the percentage of voted obtained in the election minus eight percentage points.
+	The state legislature shall approve the corresponding annual expense budget. Salaries for the public servants shall observe the provisions established in the Article 127 of this Constitution.
+	The state legislative, executive and judicial branches, as well as the autonomous entities recognized by the state constitution, shall include in their proposal for expenses budget the detailed information about salaries for their employees. These proposals shall follow the procedures provided by the state constitution and the applicable state laws.
+	State legislatures shall have a Local Auditing Office, which shall be granted with technical and managerial autonomy, as well as autonomy to decide about its internal organization, functioning and rulings according to the law. The auditing function shall be exercised according to the principles of legality, impartiality and reliability. This office shall audit the State and Municipal management of funds, local resources and public debt. The reports of the Local Auditing Office shall be public.
+	The head of the Local Auditing Office shall be appointed by the two-thirds of the members present in the House of Representatives of the state. The head of the Local Auditing Office will remain in office for a period of no less than seven years. The elected official will be required to have five years experience in matters of control, financial auditing and liabilities.
+	The public account of the previous years shall be sent to the State Legislature before April 30th of the current year. This time limit may only be postponed upon a justified request issued by the Governor and after consideration of the Legislature.
+	The State Legislature will regulate the terms for the citizens to submit legislative bills before the respective Congress.
+3. The local judicial power shall be exercised by the courts established by the corresponding state constitution.
+	The magistrates and judges shall be granted with independence in the performance of their duties by the state constitutions and the local organic laws of the respective state. These laws shall establish the requirements for admission, training and continuity of those employees of the state judicial branch.
+	Local magistrates shall meet the requirements established in sections I to V of the Article 95 of this Constitution. Persons that during the previous year to the day of the appointment have held the office of Secretary or equivalent, local Attorney General or local representative of the Congress may not be magistrate.
+	Magistrates and judges appointed shall preferably be persons who have served efficiently and honestly in the judiciary, or who deserve the position because of their honorability, abilities and previous performance in the legal career.
+	Magistrates shall hold the office during the period of time specified in the local constitution, they may be reelected and they also may be removed from office only according to the state constitution and to the States’ Public Service Accountability Act.
+	Magistrates and judges shall receive an adequate remuneration, which is non-negotiable and may not be reduced during their term in office.
+4. According to the norms stated in this Constitution and the general laws in this matter, state constitutions and local electoral laws shall guarantee that:
+	1. Elections of governors, members of the local legislatures and members of the Municipal Councils are carried out through the universal, free, secret and direct suffrage, and that the elections take place the first Sunday of June of the respective year. This provision shall not be applicable to the states where local elections take place the same year than federal elections, but not the same day.
+		2. The principles of certainty, impartiality, independence, legality, objectivity and maximum publicity shall govern the work of the electoral authorities.
+		3. The authorities in charge of organizing elections and the jurisdictional authorities that resolve electoral disputes are autonomous in the exercise of their functions and are granted with independence to make their decisions according to the following statements:
+		1. The local electoral public organs shall have a directive council formed with a President of the Council, and six electoral councilors granted with voice and vote plus an executive secretary and representative of the political parties that shall only be granted with voice before the Council. Each political party shall be granted with a representative in the council.
+				2. The President of the Council and the Electoral Councilors shall be appointed by the general Council of the National Electoral Institute according to the terms provided by law. The local electoral counselors shall be from the state they will serve as councilor or shall have at least five years of residence in the state previous to the date of the appointment. The counselors shall fulfill the requirements and the profile suitable to the position. In case that a vacancy of electoral counselors happens, the General Council of the National Electoral Institute shall make the corresponding appointment in the terms described by law and by this article. If the vacancy happens during the first four years of their term in office than a substitute shall be appointed to continue the term. If the vacancy happens during the last three years of the term in office then an electoral councilor shall be appointed for a new term in office.
+				3. The local electoral councilors shall remain in office for a seven-year period and shall not be reelected. They shall receive a salary in accordance to their functions and may be removed by the General Council of the National Electoral Institute according to the serious reasons stated by law.
+				4. The local electoral councilors and other public servants specified by law shall not hold other office or have another employment or commission except of those unpaid activities such as research, cultural, academic, scientific and altruistic activities. They shall not accept a public office in the organs in which the local electoral public organ was involved to elect their officials or representatives, and they shall not be nominated to run for a public office or hold a position in the party leadership during the next two years after finishing their term as electoral councilors.
+				5. The corresponding jurisdictional electoral authorities shall be composed by an odd number of magistrates that shall be elected by two thirds of the present members of the Senate with prior public call in the terms specified by law.
+				6. The local electoral public organs shall have public servants granted with public trust for the electoral acts and whose attributions and functions law shall define.
+				7. The challenges to the acts in regard to the local electoral process done by the National Electoral Institute, according to the part V of the Article 41 of this Constitution, shall be resolved by the Electoral Court of the Judicial Branch of the Federation according to the law.
+		4. The administrative electoral authorities have the power to make and execute an agreement with the National Electoral Institute, so that this last entity organizes local elections.
+		5. The political parties are composed of citizens only, without intervention of labor unions or other organizations, and that political parties are not affiliated to a corporation. State constitutions and state electoral laws shall also guarantee that the political parties have the right to register candidates for popular elections, except for the provisions of Article 2, section A, paragraphs III and VII, of this Constitution.
+		6. Electoral authorities shall intervene in the internal affairs of the parties only according to the provisions established by the electoral laws.
+		The local political party that does not obtain, at least, the three percent of the total effective votes casted in any of the elections for the renewal of the Executive Power or the local Congress will lose its registry. These norms shall not apply to the national political parties that participate in local elections.
+		7. The political parties shall receive public funding, in a fair manner, for their permanent ordinary activities and their electoral activities. State constitutions and state electoral laws shall also establish procedures to settle political parties that lose registration and shall decide over their properties and balances.
+		8. The definition of the criteria for the expenditure limits made by the political parties during the run-ups and campaigns, as well as to the contributions made by sympathizers and militants.
+		9. The political parties shall have access to airtime in radio and television, according to the rules established in the Article 41, section III, part B of this Constitution.
+		10. Establish the rules for the run-up and electoral campaigns, as well as the appropriate penalties to offenders. In every case, the duration of the campaigns shall be between sixty and ninety day for the Governor election and thirty to sixty days only when there are elections for local congress and Municipal Councils. The run-ups shall last no longer than two-thirds of the campaign term respectively.
+		11. Establish the regulation that applies to the nomination, registry, rights and obligations of the independent candidates guaranteeing their access to public financing and airtime in radio and television according to the terms established by this Constitution and the corresponding laws.
+		12. Establish a system of legal means of challenge to guarantee legality of the electoral acts and rulings. Define the postulates and rules to do the partial or total vote recount in regard to administrative and jurisdictional matters.
+		13. Specify the causes to annul elections for governors, for state representatives and for members of the Municipal Councils; as well as, the terms to file legal challenges and appeals, taking into account the principle of definitiveness in setting the stages of electoral processes.
+		14. At least one local election shall be held on the same date that any of the federal elections is held.
+		15. Specify and typify the electoral crimes and the penalties imposed for each one of them.
+		16. Establish the grounds and requisites for the citizenry to request their registration as independent candidates to be elected to any post subject to popular vote, in accordance with Article 35 of this Constitution.
+5. The constitutions and laws of the states may grant full autonomy to the Administrative Justice Courts to issue their resolutions, establish their internal organization, their functioning and procedures and in the case, the procedures against their resolutions. The Courts shall resolve the controversies between the local and municipal public administration and between private parties. According to the respective laws, the Courts shall impose the respective sanctions to the local or municipal public servants for severe infringements to their administrative duties and to the individuals that participate in severe administrative infringements, as well as to establish the respective compensations or pecuniary sanctions that result from the damages to the Municipal or Local Treasuries or to the resources of local or municipal entities.
+	The investigation and substantiation and punishment of the administrative responsibilities of the members of the local judicial branch shall be according to the provisions of the respective local constitution, without diminishing the responsibilities of the Auditing Office about the management, safe-keeping and use of public resources.
+6. Labor relations between the state government and its employees shall be regulated by the laws enacted by the state legislature, based on the Article 123 of this Constitution and on its statutory regulations.
+7. Federal government and state governments can agree transfer among them of some functions, provision of public services or implementation of infrastructure and works, whenever it is necessary for the economic and social development of the country.
+	State government and Municipalities can execute such agreements to provide public services or perform functions mentioned in the previous paragraph.
+8. The local constitutions shall establish specialized, impartial, collegiate and autonomous entities responsible for guarantee the right of access to information and the protection of personal data held by obligors \[sujetos obligados\], following the principles and fundamentals established in the 6th Article of this Constitution and the general basis, principles and procedures to exercise these rights stated by the general laws issued by the Mexican Congress.
+9. The State Constitutions shall guarantee that the justice administration functions are based on the principles of autonomy, efficiency, impartiality, legality, objectivity, professionalism, responsibility and respect to human rights.
+
+### Article 117
+
+In no case shall the states:
+
+1. Conclude alliances or coalitions, or make treaties with any other state or foreign government.
+2. (Repealed by the decree published on October 21, 1966)
+3. Mint money or issue money, stamps or stamped paper.
+4. Levy a road tax on the persons or goods that pass through their territory.
+5. Impede, directly or indirectly, the entrance or exit of domestic or foreign merchandises, or levy a tax on them.
+6. Levy a tax on circulation and consumption of domestic and foreign products when taxes or fees are collected by the local customs, or the packages are subject to inspection or registration, or require it to be accompanied by documents.
+7. Enact or keep in force fiscal laws or provisions that establish differences between the taxes and requirements for domestic products and those stated for foreign products, either such differences are established in respect to similar local products or between similar products of different origin.
+8. To make and execute, directly or indirectly, bonds or loan agreements with foreign governments, foreign associations or foreign private parties, or when such bonds or loans are to be paid with foreign currency or outside the country.
+	States and Municipal Councils may only make and execute bonds or loan agreements when such resources are to be allocated in the investment of productive public projects or to refinance them, these agreements must follow the best market conditions. The same applies to decentralized organs, public companies, public trusts or in the case of the States when they endorse Municipal debt. State Legislatures shall establish the basis on the corresponding law to follow this precept and to establish the concepts and amounts for these agreements. The executive power shall report these debt agreements in their annual accountability report. Never shall the governments pursue these debt agreements to cover regular expenditures.
+	State Legislatures, by a two third vote of the present members of the Congress shall authorize maximum amounts to agree on bonds and loan contracts given the best market conditions and with a previous analysis of its use, its payment capabilities, and in some cases to establish the source of payment or a payment guarantee.
+	Regardless the previous statement, States and Municipal Councils shall agree on liabilities to cover their short term needs but it may not surpass the maximum amounts or the conditions established by the general law issued by the National Congress. The short-term liabilities shall be fully paid no further than three months prior the end of the corresponding government period and no new liabilities shall be agreed within those last three months.
+9. Levy a different tax on production, store or sale of leaf snuff than the tax authorized by the Congress of the Union.
+	The Congress of the Union and the state legislatures shall enact laws to fight alcoholism.
+
+### Article 118
+
+Without the Congress of the Union’s consent, the states cannot:
+
+1. Establish tonnage duties or any other port duties, or levy a tax on importing or exports.
+2. Have permanent troops or warships.
+3. Declare war against foreign nation, except for cases of invasion or imminent danger. In such case, the state shall notify immediately the President of the Republic.
+
+### Article 119
+
+The Powers of the Union have the duty to protect the states against foreign invasion or violence. In the event of uprising or internal social unrest, the Powers of the Union must protect the state, as long as they are called by the state legislature, or by the governor if legislature is not in session.
+
+Each State and the Federal District are obliged to deliver, without delay, those suspected, processed or convicted persons required by another state, as well as to carry out confiscation and delivery of objects and instruments used in perpetration of the crime and the benefits thereof. These obligations will be complied through the respective organs of justice procurement, observing the conditions established in the collaboration agreements made by the states. For this purpose, the local authorities can make and execute collaboration agreements with the Federal Attorney General’s Office.
+
+Calls for extradition, made by a foreign State, shall be processed by the President of the Republic, with the intervention of the judicial authority in accord with the provisions stated in this Constitution, in the applicable international treaties and in the statutory laws. In those cases, the writ of the judge, ordering to comply with the call for extradition, shall be enough to cause the person requested to be detained for up to 60 calendar days.
+
+### Article 120
+
+Governors are obliged to publish and uphold federal laws.
+
+### Article 121
+
+Each state of the Federation shall give full faith and credit to the public acts, registrations and judicial proceedings made by the other states. The Congress of the Union, through general laws, shall establish the way for proving such acts, registrations and judicial proceedings and their effect, in accord with the following bases:
+
+1. The laws of a state only have effect inside its own territory; as a consequence, they have no effect outside thereof.
+2. Personal property and real estate shall be subject to the local law applicable to the place where they are located.
+3. Sentences passed by a court of a state about property rights on properties located in another state, may only be enforced in the other state when its own laws so provide it.
+	Sentences about personal rights may only be enforced in other state when the person judged has, expressly or by reason of residence, submitted himself to the jurisdiction of the courts that pronounced such sentences, provided that the person has been summoned to appear in the trial.
+4. Acts pertaining to marital status, carried out according to the laws of a state, shall be valid in the other states.
+5. University degrees issued by a state government, in accord with its laws, shall be valid in the other states.
+
+### Article 122
+
+The legal nature of the Federal District has been defined in the Article 44 of this Constitution. The Federal District Government is entrusted to the Powers of the Union together with the local executive, legislative and judicial branches, observing the provisions established in this article.
+
+The local authorities of the Federal District are: the Assembly of Representatives, the Head of the Federal District Government and the Superior Court of Justice.
+
+The Federal District’s Assembly of Representatives shall consist of a number of representatives elected according to the principle of relative majority and the principle of proportional representation, following the procedure of lists for a multi-member circumscription, according to the provisions established by this Constitution and the Federal District Charter.
+
+The Head of the Federal District Government shall exercise the executive power and shall be responsible for the public administration of the entity. The Head of the Federal District Government shall be vested in one single person, elected through universal, free, direct and secret suffrage.
+
+The Superior Court of Justice and the Judicial Council of the Federal District, together with the other bodies established by the Federal District Charter, shall perform the judicial functions related to common law in the Federal District.
+
+The distribution of areas of jurisdiction among the Powers of the Union and the local authorities of the Federal District shall be subject to the following provisions:
+
+1. It pertains to the Congress of the Union:
+	1. To legislate on what is relative to the Federal District, except for the affairs expressly conferred on the Assembly of Representatives.
+		2. To issue the Federal District Charter.
+		3. To enact laws that regulate the public debt of the Federal District.
+		4. To issue the general provisions that guarantees the appropriate, timely and efficient functioning of the Powers of the Union.
+		5. The other powers conferred by this Constitution.
+2. It pertains to the President of the Republic:
+	1. To propose laws to the Congress of the Union related to the Federal District.
+		2. To propose to the Senate the person who should substitute the Head of the Federal District Government in the event of his/her removal.
+		3. To annually submit to the Congress of the Union the proposal of indebtedness in order to fund the expenditure budget of the Federal District. The proposal shall be submitted by the Head of the Federal District Government to the President and shall meet the requirements established by law.
+		4. To uphold the administrative laws enacted by the Congress of the Union related to the Federal District.
+		5. The other powers conferred by this Constitution, the Federal District Charter and the laws.
+3. The Federal District Charter shall be subject to the following bases:
+	1. Regarding the Assembly of Representatives:
+		1. The members of the Assembly of Representatives shall be elected every three years through universal, free, direct and secret vote, in accordance with the provisions established by law. The Assembly of Representatives shall consider the provisions established in the Articles 41, 60 and 99 of this Constitution in regard to the organization of elections, the issuance of certificates and the legal challenges on electoral matter.
+				2. Qualifications to be a representative in the Assembly shall not be less than those required to be a federal deputy. The compatible provisions included in the Articles 51, 59, 61, 62, 64 and 77, paragraph IV, of this Constitution shall be applied to the Assembly of Representatives and its members.
+				3. The composition of the Legislative Assembly of the Federal District shall invariably follow the criteria stated in Article 116, fraction II, third paragraph of this Constitution.
+				4. The Assembly of Representatives shall fix the dates for the beginning of two ordinary periods of sessions per year, and shall establish the procedures to create internal organ of government that will act during its recesses, as well as the attributions of such internal organ. The internal organ of government can call to an extraordinary period of sessions at the request of the majority of its members or of the Head of the Federal District Government.
+				5. The Assembly of Representatives, observing the Federal District Charter, shall have the following powers:
+			1. To issue its own organic law and to send it to the Head of the Federal District Government so that it is published.
+						2. To review, discuss and approve annually the expense budget and the revenue law for the Federal District, approving first the contributions necessary to cover the budget. Such budget shall include the salaries of the public servants, which shall be subject to the provisions established in the Article 127 of this Constitution.
+				All the legislative, executive and judicial organs of the Federal District, as well as the autonomous bodies established by the Federal District Charter, shall include the detailed salaries of their employees in their proposals of expenditure budgets. The Federal District Charter and the applicable laws shall establish the procedure to approve the expenditure budget of the Federal District.
+				The revenue law for the Federal District cannot include indebtedness higher than those previously approved by the Congress of the Union for the financing of the Federal District expenditure budget.
+				The Head of the Federal District Government can exclusively submit the revenue law and the expenditure budget. The term to submit them ends on November 30, except for the years when the election of the Head of the Federal District Government takes place, in which case deadline shall be December 20.
+				The Assembly of Representatives shall submit annually its proposal for the budget to the Head of the Federal District Government in order to include it in the general proposal.
+				The provisions included in the Article 115, section IV, point “c”, second paragraph, of this Constitution shall be applicable to the treasury of the Federal District in all matters consistent with its nature and organic system of government.
+						3. The Representatives Assembly, through its Auditing Office shall analyze the public account that corresponds to the previous year according to the applicable criteria established in the Article 74, section VI, of this Constitution.
+				Public account of the previous year shall be submitted to the Assembly of Representatives no further than April 30. This term may be extended only when the Head of the Federal District Government justifies it sufficiently to the Assembly. The same shall apply for the extensions for submitting the revenue law and the expenditure budget.
+				The Federal District’s Auditing Office Reports shall be public.
+				The Head of the Auditing Office of the Federal District shall be elected by the two-thirds of the members present in the Assembly of Representatives, shall remain in office for at least seven years period and shall have five years experience in matters of control, financial auditing and liabilities.
+						4. To appoint a substitute for the Head of the Federal District Government in case of absolute absence.
+						5. To issue the legal provisions required to organize public treasury, the budget, bookkeeping and public spending of the Federal District, as well as the provisions required to organize the Auditing Office, vesting it with technical and operational autonomy to decide its internal organization, functioning and decision making. Auditing function shall be exercised according to the principles of legality, impartiality and reliability.
+						6. To issue the provisions required to guarantee free and authentic elections in the Federal District through universal, free, secret and direct suffrage, according to the ground rules established by the Federal District Charter, which shall observe the principles and rules provided in Article 116, section IV, paragraphs “b” to “o”, of this Constitution. Provisions established in paragraphs “j” thru “m” of the mentioned article and section making reference to the governor, local representatives and Municipal Councils shall apply, respectively, to the Head of the Federal District Government, members of the Assembly of Representatives and District Chiefs.
+						7. To legislate in matters of local administration, its internal organization and internal administrative procedures.
+						8. To regulate the Human Rights Commission and to legislate in civil and criminal matters and in other matters like citizen participation, public defender, notary service and the land and commerce registry.
+						9. To establish standards for civil protection, civic justice for police and governance offences, for the security services provided by private companies, for prevention and social reintegration, for public health and social work, and for social security.
+						10. To legislate in matters of development planning; urban development, specially on land use; environmental preservation; housing; construction; public roads; traffic and parking; acquisitions and infrastructure; and exploitation and use of the Federal District’s resources.
+						11. To regulate provision and contracts of public services; to legislate in matters of public transport, cleaning services, tourism and lodging, markets, slaughterhouse, wholesale markets and cemeteries.
+						12. To issue regulations on economic stimulations; employment protection; development of the agricultural and livestock sector; commercial establishments; animal protection; public shows; cultural, civic and sports promotion; and social education in accord with the Article 3, section VIII, of this Constitution.
+						13. To enact the organic law of the courts responsible for the common jurisdiction in the Federal District.
+						14. To issue the Organic Law of the Court of Administrative Justice
+						15. To legislate in the matter of the right of access to information and the protection of personal data held by obligors \[sujetos obligados\] of the Federal District. The Assembly of Representatives may also legislate in issues of organization, administration and management of documents and files according to the general laws issued by the Mexican Congress to establish the bases, principles and procedures to exercise this right. The Federal District shall establish an impartial, collegiate and autonomous entity responsible for guaranteeing the right of access to information and the protection of personal data held by obligors \[sujetos obligados\], this entity shall have legal personality, own patrimony, and full technical, managerial and decision-making autonomy in regard of its budget and internal organization.
+						16. To present bill proposals or decrees to the Mexican Congress in regard to the Federal District issues or governance.
+						17. To establish by law the terms and requirements by which the citizens of the Federal District may exercise their right of initiative before the Assembly of Representatives of the Federal District.
+						18. Other powers conferred expressly by this Constitution.
+		2. Regarding the Head of the Federal District Government:
+		1. The Head of the Federal District Government shall hold office for a six-year term, beginning on the 5th day of December of the year in which election was held, in accordance with the provisions established in the electoral law.
+			In order to be eligible for the office of the Head of the Federal District Government, the individual shall meet the requirements established by the Federal District Charter, including: a) to be a Mexican citizen by birth with legal capacity to exercise his rights; b) to have lived in the Federal District for the three years previous to the date of the election, if he was born in the Federal District; c) to have lived in the Federal District for the five years previous to the date of the election, in a continuous manner, if he was born in another entity; d) to be at least 30 years old on the election day; e) not to have been Head of the Federal District Government previously under any circumstance. Being appointed to fulfill federal public duties in another state does not interrupt the residence.
+			In the event of dismissal of the Head of the Federal District Government, the Senate shall appoint a substitute to finish the mandate. The President of the Republic must propose such substitute. In the event of a temporary absence of the Head of the Federal District Government, the office shall be entrusted to the public servant indicated in the Federal District Charter. In case of absolute absence, because of resignation or any other cause, the Assembly of Representatives shall appoint a substitute that finishes the term. Resignation of the Head of the Federal District Government shall be accepted only due to serious causes. The Federal District Charter shall regulate the leaves for this office.
+				2. The Head of the Federal District Government shall have the following powers and duties:
+			1. To uphold and execute the applicable laws enacted by the Congress of the Union related to the Federal District Executive Office or any of its agencies.
+						2. To issue, publish and execute the laws approved by the Assembly of Representatives through the provision of administrative means by issuing regulations, decrees and covenants that allow its proper compliance. The Head of the Federal District Government, within a ten days term, can make comments about the laws submitted to him by the Assembly of Representatives for enactment. Should the project with comments be confirmed by two-thirds of the representatives present, it must be enacted by the Head of the Federal District Government.
+						3. To submit bills to the Assembly of Representatives.
+						4. To appoint and remove freely the public servants subordinated to the local executive organ, whose appointment or dismissal is not foreseen in a different manner by this Constitution or by the applicable laws.
+						5. To manage public security services in accord with the Federal District Charter.
+						6. Other powers and duties conferred by this Constitution, the Federal District Charter and the laws.
+		3. Regarding the organization of the local public administration in the Federal District:
+		1. The Federal District Charter shall distribute attributions among the central organs and the decentralized bodies.
+				2. The Federal District Charter shall establish the political-administrative agencies in every administrative territory in which the Federal District is divided.
+			It shall also specify the criteria to carry out the territorial division of the Federal District; the responsibilities of each one of the political-administrative agencies; how to create them and detail their functioning; and, establish the relationships between such political-administrative agencies and the Head of the Federal District Government.
+			The directors of the political-administrative agencies shall be elected through a universal, free, secret and direct manner, according to the law.
+		4. Regarding the Superior Court of Justice of the Federal District and the other judicial bodies in charge of common affairs:
+		1. Magistrates composing the Superior Court of the Federal District shall meet the same requirements than the justices of the Supreme Court of Justice of the Nation. Besides, they should have professional experience at judicial affairs, preferably in the Federal District. The Supreme Court of the Federal District shall have the number of magistrates indicated in the applicable organic law.
+			In the event of vacancies, the Head of the Federal District Government shall submit his proposal to the Assembly of Representatives for approval. Magistrates shall hold the office for a term of six years. They may be ratified by the Assembly of Representatives, if so, they may be removed from office only in the cases established in the Title Four of this Constitution.
+				2. Administration, supervision and discipline of the Superior Court, trial courts and the other judicial organs shall be the responsibility of the Federal District Judicial Council, which shall be composed of seven members: the president of the Superior Court of Justice of the Federal District, who shall chair at the Judicial Council; a magistrate and two judges, elected by the two thirds of the members of the Superior Court, in plenary meeting; one councilor appointed by the Head of the Federal District Government; and two councilors appointed by the Assembly of Representatives. Councilors must meet the same requirements than magistrates. They must have professional and administrative experience; they also must be honest and honorable. Councilors appointed by the Superior Court of the Federal District must have proven experience in judicial field. Councilors shall serve for a five year-term and they shall be replaced in a staggered way. Councilors may not be appointed for a second term.
+			The Federal District Judicial Council shall appoint the judges for the Federal District, according to the provisions regulating the judicial career. The Judicial Council shall also define the quantity of courts and courtrooms belonging to the Supreme Court that shall build up the Judicial Branch of the Federal District, as well as their specialization.
+				3. Responsibilities and operating standards of the Federal District Judicial Council shall be determined taking into account the provisions established in the Article 100 of this Constitution.
+				4. The Organic Law shall state rules to provide training and updating to the public officials, as well as to develop their judicial career.
+				5. Impediments and penalties established in the Article 101 of this Constitution shall be applicable to the councilors, magistrates and judges.
+				6. The Federal District Judicial Council shall prepare the budget for the Federal District Courts and shall submit it to the Head of the Federal District Government to include it in the general budget that shall be sent to the Assembly of Representatives.
+		5. There shall be a court of administrative litigation, which shall have full autonomy to issue its resolutions and to establish its organization, functions and procedures, in some cases also to establish the corresponding challenges to its resolutions. The Administrative Court must resolve the conflicts between the Federal District’s public administration and private parties. The Court may impose, according to the law, the corresponding sanctions whenever public servants are found guilty for severe administrative responsibility and to the private parties responsible for severe administrative faults. It may also establish the corresponding economic sanctions or compensations for the damages caused to the Federal District’s Treasury or to the endowment of the Federal District’s public organs.
+		Regardless the powers of the Auditing Offices about the management, safe-keeping and use of public resources, whenever the members of the Superior Justice Court are under process of investigation or sanction for administrative responsibilities, the precepts established in the fraction II, Fourth Base of this article shall be observed.
+4. The head of the Federal District Public Prosecution Service shall be the Federal District Attorney General, who must be elected according to the conditions provided by the Federal District Charter. The Federal District Charter and the applicable organic law shall determine organization, powers and operation of the Federal District Public Prosecution Service.
+5. The provisions set forth in the section VII of the Article 115 of this Constitution shall apply to the President of the Republic. Appointment and dismissal of the public servant in direct charge of the public force shall be carried out according to the terms established in the Federal District Charter.
+6. The Senate, or the Permanent Committee, can dismiss the Head of the Federal District Government due to serious causes affecting relationship between him and the Powers of the Union, or affecting the public order in the Federal District. Dismissal request must be presented by a half of the members of the Senate or of the Permanent Committee.
+7. The City Councils of the Federal District suburbs can make and execute agreements with the Federal District Government and the Federal Government in order to create metropolitan commissions that coordinate planning and implementation of actions related to human settlements, protection of the environment, preservation and restoration of ecological balance, transport, drinking water, drainage, garbage collection, treatment and disposal of solid waste, and public security, observing the provisions established in the Article 115, section VI, of this Constitution.
+	The commissions will be created by mutual agreement of the participants. The document of creation shall determine the procedure for integration, structure and functions.
+	Through the commissions, it shall be established:
+	1. The bases to make and execute agreements inside the commissions. Such agreements shall define the territorial scope and functions of each Municipal Council regarding public works, provision of public services or actions mentioned in the first paragraph of this part.
+	2. The bases to define the specific functions of the members of the commissions, as well as the contributions of material, human and financial resources.
+	3. Other rules for the mutual and coordinated regulation for the development of the suburbs, provision of public services and implementation of other actions approved by the commissions.
+8. The prohibitions and limitations that this Constitution establishes for the states shall apply to the Federal District authorities.
+
+### TITLE SIX. Labor and Social Security
+
+### Article 123
+
+Every person has the right to have a decent and socially useful job. Therefore, job creation and social organization of work shall be encouraged according to the law.
+
+The Congress of the Union, without contravening the following basic principles, shall formulate labor laws, which shall apply as following:
+
+1. Workers, day laborers, domestic servants, artisans and, in a general way, to all labor contracts:
+	1. The maximum duration of the working day shall be eight hours.
+		2. The maximum duration of night work shall be seven hours. The following jobs are prohibited for persons under sixteen years: unhealthful or dangerous work, industrial night work and any work after ten o’clock at night.
+		3. The use of labor of minors under fifteen years of age is prohibited. Children older than fifteen years old and less than sixteen shall have a maximum working day of six hours.
+		4. For every six days of work a worker must have at least one day of rest.
+		5. During pregnancy, women shall not perform such work that requires excessive physical effort and could be dangerous regarding pregnancy. Women have the right to enjoy a disability leave due to childbirth, which shall cover six weeks previous to the birth and six weeks thereafter. During such disability leave, women shall receive their full wages and retain their employment and the rights acquired under their labor contract. During the nursing period, they shall have two special rest periods per day, consisting of half hour each one, to feed their babies.
+		6. The minimum wage shall be established in a general way or according to the occupation. General minimum wage shall govern over the different economic zones. Professional wages shall apply on specific industries, professions, trades or special works.
+		The general minimum wage must be sufficient to satisfy the normal material, social, and cultural needs of a family, and to provide the compulsory education of children. The professional minimum wage shall be fixed by taking into account the conditions of the different industrial and commercial activities.
+		A national commission composed by representatives of the workers, employers, and the Government shall fix minimum wages. This national commission may be assisted by special advisory committees if it considers them necessary for a better performance of its duties.
+		7. Equal wages shall be paid for equal work, regardless of sex or nationality.
+		8. The minimum wage shall be exempt from attachment, compensation, or deduction.
+		9. Workers are entitled to participate in profit sharing, which shall be regulated in conformity with the following rules:
+		1. A national commission, composed of representatives of workers, employers, and the Government, shall fix the percentage of profits to be distributed among workers.
+				2. The national commission shall research and study the general conditions of the national economy. It shall also take into consideration the need to promote the industrial development of the country, the reasonable interest that should be obtained by capital, and the necessary reinvestment of capital.
+				3. The national commission may revise the percentage fixed under paragraph “a” of this section, whenever new studies and research so justify.
+				4. The law may exempt newly established corporations from the obligation of sharing profits for a specified and limited number of years, as well as the exploration works and other activities so justified by their nature or peculiar conditions.
+				5. In order to determine the amount of the profits of each corporation, it will consider the taxable income, according to the provisions of the Income Tax Law, as basis for calculation the amount of profits. Workers may submit to the appropriate office of the Department of the Treasury their objections, in accordance with the procedure indicated in the law.
+				6. The workers’ right to participate in profit sharing does not imply the power to intervene in the management or administration of the company.
+		10. Wage must necessarily be paid in legal tender and cannot be paid in goods, coupons, tokens or any other instrument intended to substitute the money.
+		11. When, due to extraordinary circumstances, working hours must be extended, the salary to be paid for overtime shall be 100% more than the amount fixed for regular hours. Overtime work may never exceed three hours a day nor three times consecutively. Persons under sixteen years of age may not perform overtime.
+		12. In all farming, industrial, or mining corporations, or any other kind of business, employers are obliged to provide to workers comfortable and hygienic housing. This obligation shall be discharged through contributions made by the companies to a national housing fund, which shall provide the workers with inexpensive loans, sufficient to acquire a house.
+		The law shall create a body composed of representatives of the Federal Government, of the workers and of the employers to manage the resources of the national housing fund. The law shall establish the procedures to be followed by the workers in order to get a loan to acquire a house.
+		The companies located outside the villages are obliged to establish schools, medical services and other services necessary in the community.
+		In addition, in these work centers, when the population of the community exceeds 200 inhabitants, a tract of land of not less than five thousand square meters must be set aside to used them as public markets, municipal services and recreation centers.
+		Establishments selling intoxicating liquors and casinos are prohibited in all work centers.
+		13. The companies are obliged to provide their workers with training for the job. The statutory law shall establish the systems, methods and procedures through which employers will meet this requirement.
+		14. Employers shall be responsible for labor accidents and for occupational diseases of workers. Therefore, in accordance to the law, employers shall pay the appropriate compensation, depending on the consequences of the accident or disease such as death, temporary or permanent incapacity to work. This liability shall remain even when the employer contracts the work through an intermediary.
+		15. The employer shall observe the legal regulations on hygiene and health that are applicable to his establishment, and to adopt adequate measures for the prevention of accidents in the use of machines, instruments and materials. The employer must organize the work in such a way to protect the health and safety of workers and of unborn children, in the case of pregnant women. The law shall define the penalties applicable to offenders.
+		16. Both employers and workers shall have the right to join together for the defense of their respective interests, by forming unions, professional associations, etc.
+		17. The laws shall recognize strikes and lockouts as rights of workers and employers.
+		18. Strikes shall be legal when their purpose is to attain equilibrium between the several factors of production, harmonizing labor rights and the purposes of capital. In the case of public services, the workers must notify, at least ten days in advance, the Commission for Conciliation and Arbitration about the date agreed for the suspension of work. Strikes shall be considered as illegal only when the majority of strikers carry out violent acts against persons or property, or in the event of war, when the workers belong to governmental establishments or services.
+		19. Lockouts shall be legal only when an excess of production makes it necessary in order to maintain prices at a reasonable level, with prior approval of the Commission for Conciliation and Arbitration.
+		20. Differences or disputes between employers and workers shall be subject to the decisions of the Commission for Conciliation and Arbitration, which shall consist of an equal number of workers and employers, and one government representative.
+		21. If an employer refuses to submit the conflict to the Commission for Conciliation and Arbitration or to accept the decision thereof, the work contract shall be terminated and the employer shall give to the worker a compensation equal to three months salary, plus the liabilities originated by the conflict. This provision shall not be applicable in the case of actions covered in the following section. If the workers refuse to submit the conflict to the Commission for Conciliation and Arbitration, the work contract shall be terminated.
+		22. If an employer fires a worker without justified cause or because he has joined an association or union, or for having taken part in a lawful strike, then the employer is obliged to fulfill the work contract or to compensate the worker with a quantity equal to three months salary, whatever the worker chooses. The law shall specify those cases in which the employer may be exempted from the obligation of paying compensation. The employer is also obliged to pay a three months salary compensation to the worker if the worker leaves his employment due to the employer’s lack of honesty or because the employer mistreats the worker or worker’s wife, parents, children or siblings. The employer cannot be exempted from this liability when the mistreatment is inflicted by his subordinates or members of his family acting with his consent or tolerance.
+		23. Credits in favor of workers for wages earned within the last year, and for compensations, shall have priority over all other obligations in the event of receivership or bankruptcy.
+		24. Only the worker shall be responsible for debts acquired by himself and payable to his employer or to his employer’s associates, relatives or dependents. In no case the payment can be exacted from the members of the worker's family, nor are these debts demandable for an amount exceeding one-month salary.
+		25. Employment services shall be free for workers, whether the service is performed by a municipal office, an employment agency or any other public or private institution.
+		When providing employment services, labor demand must be taken into account. In equal conditions, the persons who are the only income source for their family shall have preference.
+		26. Every work contract made between a Mexican and a foreign employer must be authenticated by the responsible municipal authority and countersigned by the consul of the country to which the worker intends to go. Such work contract shall include a clause clearly specifying that the employer will bear the costs of repatriation.
+		27. The following conditions or clauses shall be considered null and void and not binding on the contracting parties, even if expressed in the contract:
+		1. Those that fix an inhuman working day.
+				2. Those that fix wages that are not remunerative, according to the criteria of the Commission for Conciliation and Arbitration.
+				3. Those providing a period longer than one week for the payment of a daily wage.
+				4. Those indicating as the place of payment of wages a recreation center, cheap restaurant, coffee shop, tavern, bar, or store, except for the employees of such establishments;
+				5. Those indicating the direct or indirect obligation of acquiring basic products in specific stores or places.
+				6. Those that allow the retention of wages as a fine.
+				7. Those that constitute a waiver by the worker of indemnification to which he is entitled due to labor accidents, occupational diseases, damages caused by breach of contract or dismissal.
+				8. Any other provision that imply waiver of any right granted to workers by the laws.
+		28. The laws shall determine what property constitutes the family patrimony. Such property shall be inalienable, not subject to taxes or attachment, and shall be transferrable as inheritance, simplifying the formalities thereof.
+		29. Social Security Act is enacted for social welfare. This act shall include disability benefit, retirement pension, life insurance, involuntary unemployment benefit, health services, nursery services, and other services intended to guarantee wellbeing of workers, farm workers and other kind of employees, as well as the wellbeing of their families.
+		30. Cooperatives established for the construction of inexpensive and hygienic houses to be purchased on installments by workers, shall be considered of social utility.
+		31. Enforcement of the labor laws belongs to the authorities of the states, within their respective jurisdictions. However, it is the exclusive jurisdiction of the federal authorities in matters relating to:
+		1. Industrial sector and services:
+			1. Textile industry
+						2. Electricity
+						3. Movie industry
+						4. Rubber
+						5. Sugar
+						6. Mining
+						7. Metallurgical, iron and steel industries, including the exploitation of basic minerals, their processing and steelworks, production of iron and steel in all their forms and alloys, and their rolled products.
+						8. Hydrocarbons
+						9. Petro-chemistry
+						10. Cement
+						11. Limekilns,
+						12. Automobile industry, including car parts.
+						13. Chemical industry, including pharmaceutical and drug industry.
+						14. Cellulose and paper
+						15. Oils and vegetable fat
+						16. Food production, applicable only to industries producing packed, canned or bottled products.
+						17. Bottled and canned drinks, and related industries.
+						18. Railroad workers
+						19. Basic lumber industry, including sawmills and manufacture of plywood and agglutinate materials.
+						20. Manufacture of glass bottles and flat glass, either smooth or carved.
+						21. Tobacco industry, including manufacture of tobacco products.
+						22. Bank and credit institutions.
+				2. Corporations:
+			1. Those corporations that are administered directly or in a decentralized form by the Federal Government.
+						2. Those corporations that have a contract or license granted by the Federal Government, and connected industries.
+						3. Those corporations working in federal zones or under federal jurisdiction, in territorial waters or inside the exclusive economic zone of the nation.
+		The following topics shall be the exclusive jurisdiction of the federal authorities: a) labor disputes that affect two or more states; b) collective work contracts that have been declared obligatory in more than one state; c) employer’s obligations related to educational matters, according to the respective law; d) employer’s liabilities regarding training for workers, and safety and hygiene at work centers. State authorities shall assist federal authorities in matters under local jurisdiction, in accord with the applicable statutory law.
+2. The Powers of the Union, the Federal District Government and their employees:
+	1. The maximum duration of the working day shall be eight hours. The maximum duration of night work shall be seven hours. Those in excess will be considered overtime, the salary to be paid for overtime shall be 100% more than the amount fixed for regular hours. Overtime work may never exceed three hours a day nor three times consecutively.
+		2. For every six days of work, the employee must have at least one day of rest, with full payment of wage.
+		3. Workers shall be entitled to vacations of not less than twenty days a year.
+		4. Wages shall be fixed in the respective budgets, and their amount may not be decreased while a given budget is in effect, observing the provisions stated by the Article 127 of this Constitution.
+		In no case, the wages of the public servants may be lower than the minimum wage established for the Federal District and the states.
+		5. Equal wages shall be paid for equal work, regardless the gender.
+		6. Withholdings, discounts, deductions or attachments from wages may be made only in those cases provided by law.
+		7. There shall be a system to appointment personnel according to their knowledge and skills. The State shall organize schools on public administration.
+		8. There shall be a scale in order to grant promotions in accordance with knowledge, skills and seniority. Under the same conditions, the individual representing the only source of income for his family shall have preference.
+		9. Workers may be suspended or fired only due to justified cause and according to the law.
+		In the event of unjustifiable dismissal, employees have the right to choose between reinstatement and the appropriate indemnity through the appropriate legal proceedings. In case of positions axing, the affected workers shall have the right to get another position equivalent to the position that has been eliminated or to get compensation.
+		10. Public employees shall have the right to join together in order to protect their common interests. They may also exercise their right to strike, observing the requirements prescribed by law, whenever the rights established by this article are generally and systematically violated.
+		11. Social security shall be organized according to the following minimum basis:
+		1. Social security shall cover work accidents, occupational diseases and other diseases, motherhood, retirement, disability, elderlies, and death.
+				2. In case of accident or illness, the right to work shall be retained for the time specified by law.
+				3. During pregnancy, women shall not perform such work that requires excessive physical effort and could be dangerous regarding pregnancy. Women have the right to enjoy a disability leave due to childbirth, which shall cover one month previous to the birth and two months thereafter. During such disability leave, women shall receive their full wages and retain their employment and the rights acquired under their labor contract. During the nursing period, they shall have two special rests per day, consisting of half hour each one, to feed their babies. In addition, they shall enjoy medical and obstetrical services, medicines, nursing aid and nursery services.
+				4. Worker’s family has the right to medical care and medicines, in those cases and in the proportions specified by law.
+				5. The Social Security System shall create centers for vacations and convalescence, as well as cheap grocery stores for workers and their families.
+				6. The Social Security System shall provide to workers inexpensive housing for rent or sale, in accordance with previously approved programs. Additionally, the State shall create a national housing fund and shall make contributions to it. Such fund shall provide the workers with inexpensive loans, sufficient to acquire a comfortable and hygienic house, or to build, renovate or improve their home or to pay loans used to buy a house.
+			Contributions made to the national housing fund shall be notified to the Social Security Institute. The law of such Institute, as well as the other applicable laws, shall regulate the administration of the national housing fund and shall establish procedures to grant loans to workers.
+		12. Individual, collective and inter-union conflicts shall be submitted to a Federal Court for Conciliation and Arbitration, which shall be organized as provided in the statutory law.
+		Disputes between the federal judicial branch and its employees shall be settled by the Federal Judicial Council. Disputes arising between the Supreme Court of Justice and its employees shall be resolved by the Supreme Court of Justice.
+		13. Military and naval personnel, Foreign Service personnel, public prosecutors, legal experts and members of the public security corps, shall be governed by their own laws.
+		Public prosecutors, legal experts and members of the police forces belonging to the Federation, the Federal District, the states and the municipal councils, can be dismissed if they do not meet the requirements established by law or due to liabilities as a result of their functions. If the jurisdictional authority determines that dismissal or any other form of termination is not justified, the State shall be obliged only to pay to the employee the compensation and other benefits established by law, but this shall not mean to bring the employee back to service, regardless the ruling pronounced in the trial.
+		The federal, state and municipal authorities, as well as the Federal District Government, shall implement complementary social security systems to strengthen social security for the employees of the Public Prosecution System, of the police forces and of the legal services, as well as for their families.
+		The State shall provide active members of the Army, Air Force and Navy with the benefits mentioned in the paragraph “f” of section XI of this part, through the body created for this purpose in such institutions.
+		14. The Central Bank and all the organs belonging to the Mexican banking system shall follow the provisions established in this part regarding labor relations between them and their employees.
+		15. The law shall determine what positions are to be considered as trusted positions. Persons who hold such positions shall be entitled to the social security and protection of wages.
+
+### TITLE SEVEN. General Considerations
+
+### Article 124
+
+The powers not expressly granted by this Constitution to federal officials, shall be understood to be reserved to the States.
+
+### Article 125
+
+No person may hold two federal elective offices at the same time, nor one federal and one state elective office; but an elected candidate may choose which of the two he desires to hold.
+
+### Article 126
+
+No payment may be made if it is not included in the budget or provided for by a subsequent law.
+
+### Article 127
+
+Employees of the Federal Government, the State governments, the Federal District Government and the Municipal Councils, as well as the employees of any governmental agency, semipublic companies, public trusts, autonomous bodies, and of any other public entity, shall receive an adequate remuneration for their work or commission and it shall be proportional to their responsibilities.
+
+This remuneration shall be non-negotiable and shall be fixed annually in the expenditure budgets of each organ in accord with the following bases:
+
+1. Remuneration is any payment made in cash or in kind, including expenses, bonus, rewards, incentives, commissions, compensations and any other payment, except for expenses allowance that must be supported by receipts and invoices and for labor costs for traveling in official activities.
+2. No public servant can receive remuneration higher than the remuneration established to the President of the Republic in the corresponding annual budget.
+3. No public servant can have a salary equal or higher than his/her superior’s salary, except when the exceeding part is due to the performance of several public duties or to the characteristics of the job, like a specialized technical job or a very specialized function. The addition of such remunerations shall not exceed a half of the President of the Republic’s remuneration.
+4. Only pensions, payments, loans and credits established by law, a decree, a labor contract or labor covenant shall be granted. Such benefits are not part of the remuneration. Social security services are excluded.
+5. Public servants’ remunerations and detailed salaries per position shall be public information. Such information shall specify every fixed and variable element, including payments in cash and in kind.
+6. The Congress of the Union, the State Legislatures and the Federal District’s Assembly of Representatives, within the scope of their powers, shall enact the laws necessary to enforce the provisions included in this article and all related constitutional provisions. They shall also establish criminal and administrative penalties to be applicable to public servants that circumvent this article.
+
+### Article 128
+
+Every public official, without exception, before taking office, shall swear allegiance to the Constitution and to the laws emanating thereof.
+
+### Article 129
+
+No military authority may, during peacetime, perform any functions other than those directly related to military affairs. There shall be fixed and permanent military command headquarters only in the castles, forts and warehouses immediately subordinated to the Federal Government, or in the camps, barracks or dumps established for the troops outside towns.
+
+### Article 130
+
+The historic principle of separation between the State and religion shall guide the provisions established in this article. Churches and any other religious groups shall observe the law.
+
+Only the Congress of the Union can legislate on matters of public worship, churches and religious groups. The respective public statutory law shall develop and detail the following provisions:
+
+1. Churches and religious groups shall have a legal status as religious association after the registration procedures. The law shall regulate the religious associations and shall establish the requirements to get registration.
+2. The government shall not intervene in the internal affairs of the religious associations.
+3. Mexicans can become ministers of any religious denomination. For this purpose, Mexicans and foreigners must meet the requirements established by law.
+4. Religious ministers cannot hold public offices, according to the statutory law. As citizens, religious ministers have the right to vote, but they do not have the right to be elected. Those who have ceased being church ministers with the required anticipation and by the procedures established in the law may be elected.
+5. Church ministers cannot join together for political purposes nor proselytize in favor of certain candidate, party or political association or against them. Neither may they oppose the laws of the Nation or its institutions, nor insult patriotic symbols in any form, in public meetings, in worship or in religious literature.
+
+The formation of any kind of political group with a name containing any word or other symbol related to any religion is strictly prohibited. No meeting of a political character may be held in churches or temples.
+
+The simple promise of truthfulness and fulfillment, subjects the person to the penalties established by law in the event of failing to fulfill them.
+
+Church ministers, their ascendancy, children, siblings and spouses, as well as their religious associations, cannot inherit by will from their followers, who do not have a family relationship of up to fourth grade.
+
+Acts of marital status pertain only to the administrative authorities under the terms established by law. The law shall define the effect and validity for the marital status acts.
+
+The law shall confer powers and duties on civil matters to the federal, state and municipal authorities.
+
+### Article 131
+
+Only the Federal Government can tax imports and exports, and merchandises that pass in transit through the national territory, as well as to regulate at all times, and even to prohibit, for security reasons, the circulation of merchandises across the country, regardless of their origin. However, the Federal Government cannot establish or enact, in the Federal District, those taxes and laws mentioned in sections VI and VII of the Article 117.
+
+The President of the Republic can be empowered by the Congress of the Union to: increase, decrease, or abolish tariff rates on imports and exports, that were imposed by the Congress; to establish new tariff rates; to restrict and to prohibit the importation, exportation or transit of products, articles and goods in order to regulate foreign trade, the economy of the country, the stability of domestic production, or for accomplishing any other purpose to the benefit of the country. The President of the Republic shall send to the Congress, together with the annual budget, a report about the way he has exercised this power.
+
+### Article 132
+
+The forts, barracks, warehouses and other buildings used by the Federal Government to provide public services or for public use, shall be subject to the jurisdiction of the federal powers in accordance with the law enacted by the Congress of the Union. However, if the Federal Government acquires properties in the future within the territory of any state, in order to put such property under federal jurisdiction, the consent of the respective legislature shall be necessary.
+
+### Article 133
+
+This Constitution, the laws derived from and enacted by the Congress of the Union, and all the treaties made and execute by the President of the Republic, with the approval of the Senate, shall be the supreme law of the country. The judges of each state shall observe the Constitution, the laws derived from it and the treaties, despite any contradictory provision that may appear in the constitutions or laws of the states.
+
+### Article 134
+
+Economic resources available for the federal, state and municipal governments, for the Federal District, and for the political-administrative bodies belonging to it, shall be managed with efficiency, effectiveness, best use of resources, transparency and honesty in order to achieve the objectives for which they are intended.
+
+The results of the use of such resources shall be assessed by the technical agencies created by the federal, states and the Federal District Governments in order to guarantee that such resources are distributed in the appropriate budgets observing the principles stated in the previous paragraph, without prejudice to that established in the article 74, section VI, and article 79.
+
+All contracts made by the authorities and entities mentioned before on acquisitions, renting, transfers, provision of services and works shall be awarded by open tenders, where bidders submit their sealed bids. These sealed bids will be opened in public for scrutiny and to guarantee that the State get the best market conditions available in regard to price, quality, financing, opportunity and other appropriate conditions.
+
+When tender is not appropriate to guarantee the conditions mentioned in the previous paragraph, the law shall establish the bases, procedures, regulations, requirements and other conditions necessary to prove the good price, effectiveness, efficiency, impartiality and honesty of the process for the benefit of the State.
+
+Management of federal economic resources by state governments, municipal governments, the Federal District Government and its political-administrative bodies shall be carried out observing the basis established in this article and the applicable statutory laws. Revision of the use of such resources shall be made by the technical state agencies mentioned in the second paragraph of this article.
+
+Public servants shall be accountable for any violation committed against the provisions established in this article, according to the terms stated in the Title Four of this Constitution.
+
+The public servants working in the federal, state and local governments, as well as the Federal District public servants are always obliged to impartially invest the public resources under their management and not to affect the equity of the competition between political parties.
+
+Propaganda disseminated through any media by the government, the autonomous bodies, the government agencies or any other entity belonging to any of the three levels of government, shall be institutional and shall bring information, education or guiding. Such propaganda cannot include names, images, voices or symbols that imply the personal promotion of a public servant.
+
+The laws shall, within their field, guarantee enforcement of the two previous paragraphs and shall define penalties to be applied to offenders.
+
+### TITLE EIGHT. Constitutional Reforms
+
+### Article 135
+
+This Constitution may be subject to amendments. The vote of two-thirds of the present members of the Congress of the Union is required to make amendments or additions to the Constitution. Once the Congress agrees on the amendments or additions, these must be approved by the majority of state legislatures.
+
+The Congress of the Union or the Permanent Committee, as appropriate, shall count the votes of the legislatures and shall announce those additions or amendments that have been approved.
+
+### TITLE NINE. The Inviolability of the Constitution
+
+### Article 136
+
+This Constitution shall not lose force and effect, even if its observance is interrupted by a rebellion. In the event that a government, whose principles are contrary to those that are sanctioned herein, is established through any public disturbance, as soon as the people recover their liberty, its observance shall be reestablished, and those who have taken part in the government emanating from the rebellion, as well as those who have cooperated with such persons, shall be judged in accordance with this Constitution and the laws derived from it.
+
+### TRANSITORY ARTICLES
+
+### Article 1
+
+This Constitution shall be published at once and, with the greatest solemnity, an oath of allegiance to the Constitution must be taken in order to uphold it throughout the Republic; except for the provisions relating to the election of the supreme federal and state powers, which shall enter into force at once. This Constitution will come into force the first day of May 1917. In such date, the Constitutional Congress shall be formally installed, and the citizen elected as the President of the Republic in the next elections shall swear an oath to exercise the office.
+
+In the elections that must be called in accordance with the following article, section V of the Article 82 shall not apply, and to be in active service in the Army shall not be an impediment to become a representative or senator, provided that such service is not command of forces in the electoral district in question. In the same way, Secretaries and under-Secretaries can be elected for the next Congress of the Union, provided that they definitely resign their position on the day that the respective call is issued.
+
+### Article 2
+
+As soon as this Constitution is published, the President of the Republic shall call for elections for the federal powers, endeavoring to do this in such a way that the Congress shall be organized promptly, since it must declare the winner of the elections for the Presidency, after the count of the votes casted, so that the provisions of the preceding article could be complied.
+
+### Article 3
+
+The next constitutional term for representatives and senators shall begin to run on September first of last year, and for the President of the Republic from December 1, 1916.
+
+### Article 4
+
+Senators bearing even numbers at the next election shall hold office for two years only, in order to change the half of the Senate every two years.
+
+### Article 5
+
+The Congress of the Union shall elect the magistrates of the Supreme Court of Justice of the Nation next May in order to have the Court installed by June first.
+
+At this election, the Article 96 shall not govern with respect to the proposals of candidates by the local legislatures. However, the elected candidates shall hold office only for the first two-year term established in the Article 94.
+
+### Article 6
+
+The Congress of the Union shall have an extraordinary period of session, which will begin on April 15, 1917. In such period, the Congress shall become an electoral college to count the votes, approve the election for the President of the Republic and declare the winner. In this same extraordinary period of sessions, the Congress shall enact the Organic Law for the circuit and district courts and the Organic Law for the Federal District courts, so that the Supreme Court of Justice of the Nation may immediately appoint the circuit magistrates and district judges. In addition, the Congress of the Union shall appoint the judges of first instance for the Federal District and shall enact all laws requested by the President of the Republic. The circuit magistrates, the district judges and the magistrates and judges of the Federal District must assume office before July 1, 1917, at which time those persons who had been appointed by the current President of the Republic shall resign.
+
+### Article 7
+
+This time only, a counting board must be created for each electoral district. The counting board of the first electoral district in each states and the Federal District shall count the votes for Senators, and these boards shall issue the majority certificate to the senators elected.
+
+### Article 8
+
+The Supreme Court of Justice of the Nation shall settle the pending Amparo trials, observing the current laws.
+
+### Article 9
+
+The President of the Republic is empowered to enact the Electoral Law, under which, this time the elections shall be held to create the Powers of the Union.
+
+### Article 10
+
+Persons who have taken part in the government formed by the rebellion against the legitimate Government of the Republic, or those who cooperated with it, afterwards combating with arms or holding office or employment with the factions that attacked the Constitutional Government, shall be tried under laws in force, unless they have been pardoned by the Constitutional Government.
+
+### Article 11
+
+Until the Congress of the Union and the state legislatures enact laws governing the agrarian and labor affairs, the bases established in this Constitution for such affairs shall take effect throughout the country.
+
+### Article 12
+
+Mexicans who have fought in the Constitutional Army, and their children and widows, as well as other persons who rendered services to the Revolution or to public education, shall have priority to acquire land according to the Article 27 and shall have the right to discounts specified by law.
+
+### Article 13
+
+All debts contracted by workers, by reason of their labor, until the date of this Constitution, with employers, their families, or intermediaries are hereby extinguished in full.
+
+### Article 14
+
+The Secretariat of Justice is hereby abolished.
+
+### Article 15
+
+Hereby, the President of the Republic is empowered to issue the tort law applicable to the offenders, accomplices and accessories to the crimes perpetrated against the constitutional order during the month of February 1913 and against the Constitutional Government.
+
+### Article 16
+
+The Constitutional Congress, in the next ordinary period of sessions starting on September 1 this year, shall enact all organic laws of this Constitution that have not already been enacted in the extraordinary period of sessions mentioned in the sixth transitory article. The Congress shall give priority to laws related to fundamental rights and to the Articles 30, 32, 33, 35, 36, 38, 107 and the last part of the Article 111 of this Constitution.
+
+### Article 17
+
+Churches, temples and other properties belonging to the Federal Government, based on the provisions established in the section II of the Article 27 of this Constitution, which is reformed through this decree, shall maintain their current legal status.


### PR DESCRIPTION
## Summary

Fixes the 5th recall bug: `layerNode.search()` bounded its internal result set by `k` (number of results to return) instead of `efSearch` (the exploration beam width). Per the HNSW paper's Algorithm 5 (SEARCH-LAYER), the found-neighbors set must be bounded by `ef`; results are trimmed to `k` only after the search completes.

With k=3 and efSearch=100, the result set held only 3 entries. The worst-result threshold converged to a local minimum within a few iterations, triggering early termination before reaching the true nearest neighbors. This required efSearch≈400 (~50% of the graph) to find correct results, effectively degrading HNSW to near-brute-force.

### Changes to `graph.go` `layerNode.search()`

1. Result set capacity and bounds changed from `k` to `efSearch`
2. Candidate insertion guarded by result improvement check (standard HNSW algorithm)
3. Post-search sort and trim to `k` results with deterministic tiebreaking

**Depends on #17** — uses the integration test infrastructure added there for validation.

## Test plan

- [x] `go test -short ./...` — all 48 tests pass
- [x] `go test ./...` — integration tests confirm recall improvement
- [x] Constitution search for "Bear Arms" returns 2nd Amendment as result #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)