### PR TITLE
perf: use vek32 SIMD for EuclideanDistance

### DIFF
--- a/distance.go
+++ b/distance.go
@@ -1,7 +1,6 @@
 package hnsw
 
 import (
-	"math"
 	"reflect"
 
 	"github.com/viterin/vek/vek32"
@@ -17,13 +16,7 @@ func CosineDistance(a, b []float32) float32 {
 
 // EuclideanDistance computes the Euclidean distance between two vectors.
 func EuclideanDistance(a, b []float32) float32 {
-	// TODO: can we speedup with vek?
-	var sum float32 = 0
-	for i := range a {
-		diff := a[i] - b[i]
-		sum += diff * diff
-	}
-	return float32(math.Sqrt(float64(sum)))
+	return vek32.Distance(a, b)
 }
 
 var distanceFuncs = map[string]DistanceFunc{

--- a/distance_test.go
+++ b/distance_test.go
@@ -30,6 +30,15 @@ func TestCosineSimilarity(t *testing.T) {
 	require.InDelta(t, 0, CosineDistance(a, b), 0.000001)
 }
 
+func BenchmarkEuclideanDistance(b *testing.B) {
+	v1 := randFloats(1536)
+	v2 := randFloats(1536)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		EuclideanDistance(v1, v2)
+	}
+}
+
 func BenchmarkCosineSimilarity(b *testing.B) {
 	v1 := randFloats(1536)
 	v2 := randFloats(1536)


### PR DESCRIPTION
## Summary

`EuclideanDistance` used a plain Go loop while `CosineDistance` already used `vek32` with AVX2 SIMD acceleration. This replaces the loop with `vek32.Distance`, resolving the TODO at `distance.go:20`.

Benchmark at 1536 dimensions (OpenAI default) on AMD Ryzen 7 7745HX:

```
Before: EuclideanDistance  335 ns/op
After:  EuclideanDistance   47 ns/op  (7.1x faster)
Cosine: CosineDistance      80 ns/op  (unchanged, already SIMD)
```

The `vek` dependency is already in `go.mod` — no new dependencies.

Also adds `BenchmarkEuclideanDistance` to `distance_test.go` for parity with the existing `BenchmarkCosineSimilarity`.

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `go test -bench=BenchmarkEuclidean -benchmem` — confirms 7x speedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)