### PR TITLE
fix: heap Max() and PopLast() return wrong element

### DIFF
--- a/graph_test.go
+++ b/graph_test.go
@@ -113,13 +113,15 @@ func TestGraph_AddSearch(t *testing.T) {
 	)
 
 	require.Len(t, nearest, 4)
+	// The two closest are 64 and 65 (distance 0.5 each).
+	// The next two are 63 and 66 (distance 1.5 each).
 	require.EqualValues(
 		t,
 		[]Node[int]{
 			{64, Vector{64}},
 			{65, Vector{65}},
-			{62, Vector{62}},
 			{63, Vector{63}},
+			{66, Vector{66}},
 		},
 		nearest,
 	)

--- a/heap/heap.go
+++ b/heap/heap.go
@@ -70,8 +70,9 @@ func (h *Heap[T]) Pop() T {
 	return heap.Pop(&h.inner).(T)
 }
 
+// PopLast removes and returns the maximum element from the heap.
 func (h *Heap[T]) PopLast() T {
-	return h.Remove(h.Len() - 1)
+	return h.Remove(h.maxIndex())
 }
 
 // Remove removes and returns the element at index i from the heap.
@@ -85,9 +86,22 @@ func (h *Heap[T]) Min() T {
 	return h.inner.data[0]
 }
 
+// maxIndex returns the index of the maximum element by scanning leaf nodes.
+// In a min-heap the max is always a leaf (indices n/2 .. n-1).
+func (h *Heap[T]) maxIndex() int {
+	n := h.inner.Len()
+	best := n / 2
+	for i := best + 1; i < n; i++ {
+		if h.inner.data[best].Less(h.inner.data[i]) {
+			best = i
+		}
+	}
+	return best
+}
+
 // Max returns the maximum element in the heap.
 func (h *Heap[T]) Max() T {
-	return h.inner.data[h.inner.Len()-1]
+	return h.inner.data[h.maxIndex()]
 }
 
 func (h *Heap[T]) Slice() []T {

--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -32,3 +32,20 @@ func TestHeap(t *testing.T) {
 		t.Errorf("Heap did not return sorted elements: %+v", inOrder)
 	}
 }
+
+func TestHeap_MaxAndPopLast(t *testing.T) {
+	h := Heap[Int]{}
+	values := []Int{5, 1, 9, 3, 7, 2, 8, 4, 6}
+	for _, v := range values {
+		h.Push(v)
+	}
+
+	require.Equal(t, Int(9), h.Max(), "Max should return the largest element")
+	require.Equal(t, Int(1), h.Min(), "Min should return the smallest element")
+
+	// PopLast should remove and return the maximum.
+	popped := h.PopLast()
+	require.Equal(t, Int(9), popped)
+	require.Equal(t, Int(8), h.Max(), "Max should be 8 after removing 9")
+	require.Equal(t, 8, h.Len())
+}


### PR DESCRIPTION
## Summary

- `Max()` returned `data[len-1]`, which is not the maximum in a binary min-heap
- `PopLast()` called `Remove(Len()-1)`, removing an arbitrary element instead of the worst
- This caused incorrect evictions during neighbor selection, silently degrading graph quality

Fix: scan leaf nodes (indices `n/2..n-1`) to find the true maximum.

## Test plan

- [x] Added `TestHeap_MaxAndPopLast` — pushes known values, asserts Max/PopLast return the largest
- [x] Updated `TestGraph_AddSearch` — expected results now reflect correct eviction behavior
- [x] `go test ./...` and `go vet ./...` pass