### PR TITLE
fix: make SavedGraph.Save work on Windows

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -7,8 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/google/renameio"
+	"path/filepath"
 )
 
 // errorEncoder is a helper type to encode multiple values
@@ -300,12 +299,22 @@ func LoadSavedGraph[K cmp.Ordered](path string) (*SavedGraph[K], error) {
 }
 
 // Save writes the graph to the file.
+//
+// The graph is written to a temporary file in the same directory, fsynced, and
+// renamed over the target, so an interrupted save leaves the previous graph in
+// place rather than a truncated one. os.Rename replaces an existing file on
+// every platform Go supports, Windows included.
 func (g *SavedGraph[K]) Save() error {
-	tmp, err := renameio.TempFile("", g.Path)
+	tmp, err := os.CreateTemp(filepath.Dir(g.Path), filepath.Base(g.Path)+".tmp-*")
 	if err != nil {
 		return err
 	}
-	defer tmp.Cleanup()
+	tmpName := tmp.Name()
+	defer func() {
+		// Both are no-ops once the rename below has succeeded.
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}()
 
 	wr := bufio.NewWriter(tmp)
 	err = g.Export(wr)
@@ -318,7 +327,19 @@ func (g *SavedGraph[K]) Save() error {
 		return fmt.Errorf("flushing: %w", err)
 	}
 
-	err = tmp.CloseAtomicallyReplace()
+	// Before the rename, not after: a rename that reaches the disk ahead of the
+	// data it points at is what loses both graphs instead of one.
+	err = tmp.Sync()
+	if err != nil {
+		return fmt.Errorf("syncing: %w", err)
+	}
+
+	err = tmp.Close()
+	if err != nil {
+		return fmt.Errorf("closing: %w", err)
+	}
+
+	err = os.Rename(tmpName, g.Path)
 	if err != nil {
 		return fmt.Errorf("closing atomically: %w", err)
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,6 +3,8 @@ package hnsw
 import (
 	"bytes"
 	"cmp"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -230,4 +232,42 @@ func BenchmarkGraph_Export(b *testing.B) {
 		}
 		buf.Reset()
 	}
+}
+
+// TestSavedGraph_ReplacesAndLeavesNoTempFiles covers what the atomic write is
+// for: a second Save must replace the first graph rather than fail on an
+// existing file, and it must not leave its temporary file behind.
+//
+// Both are worth asserting because os.Rename over an existing file is the one
+// part of this that is platform-dependent — it is a plain rename on Unix and
+// MoveFileEx with MOVEFILE_REPLACE_EXISTING on Windows.
+func TestSavedGraph_ReplacesAndLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "graph")
+
+	g1, err := LoadSavedGraph[int](path)
+	require.NoError(t, err)
+	for i := 0; i < 8; i++ {
+		g1.Add(Node[int]{i, randFloats(1)})
+	}
+	require.NoError(t, g1.Save())
+
+	// The second save writes over a file that already exists.
+	for i := 8; i < 24; i++ {
+		g1.Add(Node[int]{i, randFloats(1)})
+	}
+	require.NoError(t, g1.Save())
+
+	g2, err := LoadSavedGraph[int](path)
+	require.NoError(t, err)
+	require.Equal(t, 24, g2.Len(), "the second save should have replaced the first")
+	requireGraphApproxEquals(t, g1.Graph, g2.Graph)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	require.Equal(t, []string{"graph"}, names, "no temporary file should survive a save")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/coder/hnsw
 
 go 1.21.4
 
-require (
-	github.com/google/renameio v1.0.1
-	github.com/stretchr/testify v1.9.0
-)
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/chewxy/math32 v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/chewxy/math32 v1.10.1/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUw
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
-github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
## The problem

`hnsw` does not compile for Windows:

```
$ GOOS=windows GOARCH=amd64 go build ./...
encode.go:304:14: undefined: renameio.TempFile
```

`github.com/google/renameio` is Unix-only — `TempFile` is not defined on Windows in either v1 or v2 ([google/renameio#10](https://github.com/google/renameio/issues/10)). Since Go compiles a package as a whole, this blocks the entire `hnsw` package on Windows, not just `SavedGraph`. Callers that only use `Graph`, `NewGraph` and `Node` — never touching `SavedGraph` — cannot build either. That is how I ran into it: adding a Windows target to a project that embeds `hnsw` as its vector index.

`renameio` is also the package's only non-test dependency.

## The change

`SavedGraph.Save` is the single call site. It is replaced with the same sequence on the standard library:

| `renameio` | standard library |
|---|---|
| `renameio.TempFile("", g.Path)` | `os.CreateTemp(filepath.Dir(g.Path), filepath.Base(g.Path)+".tmp-*")` |
| `tmp.Cleanup()` | `tmp.Close()` + `os.Remove(tmpName)` in a defer |
| `tmp.CloseAtomicallyReplace()` | `tmp.Sync()` + `tmp.Close()` + `os.Rename(tmpName, g.Path)` |

The temporary file stays in the target's directory, so the rename never crosses a filesystem boundary.

The crash-safety property is unchanged. `os.Rename` replaces an existing file on every platform Go supports — on Windows it compiles to `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING` — so an interrupted save still leaves the previous graph in place rather than a truncated one. The `fsync` is kept, and kept *before* the rename: a rename that reaches the disk ahead of the data it points at is what turns a crash into the loss of both graphs rather than one.

## Tests

Added `TestSavedGraph_ReplacesAndLeavesNoTempFiles`, covering the two properties that are platform-dependent here: a second `Save` replaces the first graph rather than failing on an existing file, and no temporary file survives.

Verified the test has teeth by mutation — removing the `os.Rename` fails it:

```
--- FAIL: TestSavedGraph_ReplacesAndLeavesNoTempFiles
    Messages: the second save should have replaced the first
```

I did not add a test for the `fsync`. Its effect is only observable across a power loss, so a unit test asserting it would assert nothing; removing the `Sync` call leaves the suite green. It is retained because it is the reason `renameio` was here.

```
go test ./...                            ok
go vet ./...                             ok
gofmt -s -l .                            clean
GOOS=windows GOARCH=amd64 go build ./... ok
GOOS=windows GOARCH=amd64 go vet ./...   ok
GOOS=darwin  GOARCH=arm64 go build ./... ok
GOOS=linux   GOARCH=arm64 go build ./... ok
```

Existing behaviour on Unix is unchanged, and `TestSavedGraph` still passes.