### PR TITLE
fix: reject invalid graphs in Import instead of panicking later

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -38,6 +38,9 @@ func binaryRead(r io.Reader, data interface{}) (int, error) {
 		if err != nil {
 			return 0, err
 		}
+		if ln < 0 {
+			return 0, fmt.Errorf("invalid string length: %d", ln)
+		}
 
 		s := make([]byte, ln)
 		_, err = binaryRead(r, &s)
@@ -49,6 +52,9 @@ func binaryRead(r io.Reader, data interface{}) (int, error) {
 		_, err := binaryRead(r, &ln)
 		if err != nil {
 			return 0, err
+		}
+		if ln < 0 {
+			return 0, fmt.Errorf("invalid vector length: %d", ln)
 		}
 
 		*v = make([]float32, ln)
@@ -207,6 +213,13 @@ func (h *Graph[K]) Import(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+	if nLayers < 0 {
+		return fmt.Errorf("invalid number of layers: %d", nLayers)
+	}
+
+	// Every vector must share the dimensionality of the vectors already in
+	// the graph, or of the first vector decoded if it is empty.
+	dims := h.Dims()
 
 	h.layers = make([]*layer[K], nLayers)
 	for i := 0; i < nLayers; i++ {
@@ -214,6 +227,9 @@ func (h *Graph[K]) Import(r io.Reader) error {
 		_, err = binaryRead(r, &nNodes)
 		if err != nil {
 			return err
+		}
+		if nNodes < 0 {
+			return fmt.Errorf("invalid number of nodes in layer %d: %d", i, nNodes)
 		}
 
 		nodes := make(map[K]*layerNode[K], nNodes)
@@ -224,6 +240,14 @@ func (h *Graph[K]) Import(r io.Reader) error {
 			_, err = multiBinaryRead(r, &key, &vec, &nNeighbors)
 			if err != nil {
 				return fmt.Errorf("decoding node %d: %w", j, err)
+			}
+			if nNeighbors < 0 {
+				return fmt.Errorf("invalid neighbor count for node %v: %d", key, nNeighbors)
+			}
+			if dims == 0 {
+				dims = len(vec)
+			} else if len(vec) != dims {
+				return fmt.Errorf("node %v has a %d-dimensional vector, expected %d dimensions", key, len(vec), dims)
 			}
 
 			neighbors := make([]K, nNeighbors)
@@ -252,7 +276,11 @@ func (h *Graph[K]) Import(r io.Reader) error {
 		// Fill in neighbor pointers
 		for _, node := range nodes {
 			for key := range node.neighbors {
-				node.neighbors[key] = nodes[key]
+				target, ok := nodes[key]
+				if !ok {
+					return fmt.Errorf("node %v has neighbor %v, but it is not present in its layer", node.Key, key)
+				}
+				node.neighbors[key] = target
 			}
 		}
 		h.layers[i] = &layer[K]{nodes: nodes}

--- a/encode_test.go
+++ b/encode_test.go
@@ -180,6 +180,154 @@ func TestSavedGraph(t *testing.T) {
 
 const benchGraphSize = 100
 
+// encodeTestPayload encodes vals using the wire format of Export.
+func encodeTestPayload(t *testing.T, vals ...any) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	_, err := multiBinaryWrite(buf, vals...)
+	require.NoError(t, err)
+	return buf
+}
+
+func TestGraph_ImportRejectsDanglingNeighbor(t *testing.T) {
+	t.Parallel()
+
+	// One layer holding a single node whose only neighbor references a key
+	// that is absent from the layer. Importing this must fail rather than
+	// produce a graph containing nil neighbors that panics on Search.
+	buf := encodeTestPayload(
+		t,
+		encodingVersion,
+		16,
+		0.25,
+		20,
+		"cosine",
+		1,               // layers
+		1,               // nodes
+		1,               // key
+		Vector{1, 0, 0}, // value
+		1,               // neighbors
+		999,             // dangling neighbor key
+	)
+
+	g := NewGraph[int]()
+	err := g.Import(buf)
+	require.ErrorContains(t, err, "not present")
+}
+
+func TestGraph_ImportRejectsInconsistentDims(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithinFile", func(t *testing.T) {
+		t.Parallel()
+
+		// Two nodes whose vectors have different dimensions must be
+		// rejected: searching such a graph panics inside the distance
+		// function depending on which node becomes the entry point.
+		buf := encodeTestPayload(
+			t,
+			encodingVersion,
+			16,
+			0.25,
+			20,
+			"cosine",
+			1,               // layers
+			2,               // nodes
+			1,               // key
+			Vector{1, 0, 0}, // value
+			0,               // neighbors
+			2,               // key
+			Vector{1, 0},    // value
+			0,               // neighbors
+		)
+
+		g := NewGraph[int]()
+		err := g.Import(buf)
+		require.ErrorContains(t, err, "dimensions")
+	})
+
+	t.Run("AgainstGraph", func(t *testing.T) {
+		t.Parallel()
+
+		// Like Add, importing into a populated graph requires matching
+		// dimensionality.
+		g := NewGraph[int]()
+		g.Add(MakeNode(1, Vector{1}))
+
+		buf := encodeTestPayload(
+			t,
+			encodingVersion,
+			16,
+			0.25,
+			20,
+			"cosine",
+			1,            // layers
+			1,            // nodes
+			2,            // key
+			Vector{1, 0}, // value
+			0,            // neighbors
+		)
+
+		err := g.Import(buf)
+		require.ErrorContains(t, err, "dimensions")
+	})
+}
+
+func TestGraph_ImportRejectsInvalidCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(t *testing.T) *bytes.Buffer{
+		"negativeLayers": func(t *testing.T) *bytes.Buffer {
+			return encodeTestPayload(t, encodingVersion, 16, 0.25, 20, "cosine", -1)
+		},
+		"negativeNodes": func(t *testing.T) *bytes.Buffer {
+			return encodeTestPayload(t, encodingVersion, 16, 0.25, 20, "cosine", 1, -2)
+		},
+		"negativeNeighbors": func(t *testing.T) *bytes.Buffer {
+			return encodeTestPayload(
+				t,
+				encodingVersion,
+				16,
+				0.25,
+				20,
+				"cosine",
+				1,         // layers
+				1,         // nodes
+				1,         // key
+				Vector{1}, // value
+				-3,        // neighbors
+			)
+		},
+		"negativeVectorLength": func(t *testing.T) *bytes.Buffer {
+			return encodeTestPayload(
+				t,
+				encodingVersion,
+				16,
+				0.25,
+				20,
+				"cosine",
+				1,  // layers
+				1,  // nodes
+				1,  // key
+				-4, // vector length
+				0,  // neighbors
+			)
+		},
+	}
+
+	for name, encode := range tests {
+		name, encode := name, encode
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := encode(t)
+			g := NewGraph[int]()
+			err := g.Import(payload)
+			require.Error(t, err)
+		})
+	}
+}
+
 func BenchmarkGraph_Import(b *testing.B) {
 	b.ReportAllocs()
 	g := newTestGraph[int]()


### PR DESCRIPTION
## Problem

`Graph.Import` trusted the encoded payload structurally. Three classes of malformed input decoded successfully and produced a graph that panics later, far from the cause:

**1. Dangling neighbor reference -> nil-pointer panic on Search**

A node whose neighbor list references a key absent from its layer got a `nil` `*layerNode` stored in its neighbor map (encode.go filled pointers with `nodes[key]`, which silently yields `nil` on a miss). The first `Search` over the graph panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/coder/hnsw.(*layerNode[...]).search(...)  graph.go:135
github.com/coder/hnsw.(*Graph[...]).search(...)      graph.go:477
github.com/coder/hnsw.(*Graph[...]).Search(...)      graph.go:433
```

Reproduced against current main by importing a hand-crafted payload (one layer, one node, one neighbor key not present) and then searching.

**2. Inconsistent vector dimensionality -> panic inside the distance function**

Import enforced no dimensionality constraint, although the doc comment carves out dimensionality as the one thing that must match, and `assertDims` enforces uniformity for `Add`. A file containing vectors of different lengths imports cleanly; afterwards `Search` panics inside vek32 depending on which node map iteration picks as entry point:

```
panic: slices must be of equal length
github.com/viterin/vek/vek32.CosineSimilarity(...)
github.com/coder/hnsw.CosineDistance(...)  distance.go:14
github.com/coder/hnsw.(*layerNode[...]).search(...)  graph.go:101
```

The same applies to importing a differently-dimensional file into a populated graph.

**3. Negative counts -> panic during decoding**

Negative layer/node/neighbor/vector-length varints reach `make(...)` (`make([]*layer[K], -1)`, `make([]K, -3)`, `make([]float32, -4)`) and panic inside `Import` instead of returning an error.

## Fix

Validate while decoding and return errors, consistent with the existing version / distance-function checks:

- neighbor keys must exist in their layer (`node %v has neighbor %v, but it is not present in its layer`)
- every vector must match the dimensionality of the first decoded vector, or of the target graph when it is non-empty
- negative counts are rejected before reaching `make`
- negative string/vector lengths are rejected in `binaryRead`

Valid `Export` output never trips any of the new checks: neighbors are always intra-layer by construction, and `assertDims` keeps dimensions uniform across a graph.

## Verification

New tests (`encode_test.go`), all passing locally on Go 1.26:

- `TestGraph_ImportRejectsDanglingNeighbor` - failed with the nil-pointer panic above on unpatched main; now `Import` errors
- `TestGraph_ImportRejectsInconsistentDims/WithinFile` - panicked in vek32 on unpatched main; now errors
- `TestGraph_ImportRejectsInconsistentDims/AgainstGraph` - same for import into a populated graph
- `TestGraph_ImportRejectsInvalidCounts/{negativeLayers,negativeNodes,negativeNeighbors,negativeVectorLength}` - panicked in `make` before; now error
- Full existing suite (`go test ./...`, includes `TestGraph_ExportImport` roundtrip and `TestSavedGraph`) passes unchanged

Performance (`BenchmarkGraph_Import`, 100 nodes x 256 dims): allocations are byte-identical before/after (3016 allocs/op, ~491 KiB/op). Timings on my noisy Windows laptop were inconclusive run-to-run, but the change adds only an `ok` check to a map lookup that already existed plus integer comparisons per node - no new allocations or passes over the data.
